### PR TITLE
add warning about no man in GitBash

### DIFF
--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -488,9 +488,15 @@ The quotes around the text can also be safely omitted in this case, but that isn
 
 - Software Carpentries offers an open source course [introducing new users to the Unix Shell](https://swcarpentry.github.io/shell-novice/)
 
-### The bash manual
+### Getting help from the manual
 
-The bash manual is available to you whenever you are in a bash shell.  Entering `man command_name` reveals the documentation (`man` is short for "manual") for the function `command_name`.  This can be useful if you think a command might be useful and want to learn more about it, or have forgotten how to use a command or what its options are.
+<div class="warning">
+
+The bash manual is available to you in most bash shells, although not in Git Bash. If you are using Git Bash, an internet search for "`command_name` bash manual" will usually get you the same information.
+
+</div>
+
+Entering `man command_name` reveals the documentation (`man` is short for "manual") for the function `command_name`.  This can be useful if you think a command might be useful and want to learn more about it, or have forgotten how to use a command or what its options are.
 
 For example if you wanted to know more about the command `grep` you could type `man grep`. The output contains a description. The first sentence of the description tells us what `grep` does, it "searches any given input files, selecting lines that match one or more patterns."
 

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -488,7 +488,7 @@ The bash manual is available to you in most bash shells, although not in Git Bas
 
 </div>
 
-Entering `man command_name` reveals the documentation (`man` is short for "manual") for the function `command_name`.  This can be useful if you think a command might be useful and want to learn more about it, or have forgotten how to use a command or what its options are.
+Entering `man command_name` reveals the documentation for the function `command_name`  (`man` is short for "manual").  This can be helpful if you think a command might be useful and want to learn more about it, or have forgotten how to use a command or what its options are.
 
 For example if you wanted to know more about the command `grep` you could type `man grep`. The output contains a description. The first sentence of the description tells us what `grep` does, it "searches any given input files, selecting lines that match one or more patterns."
 

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -110,7 +110,7 @@ You do not need to configure Git at the this time, so following the instructions
 Once you have Git Bash installed, you are ready to get started learning how to use the bash shell!
 
 
-## The bash shell
+## The Bash Shell
 
 Your computer has an **Operating System** (OS), most commonly either Windows, Mac, or Linux. The core for the OS itself is called the **kernel**; it's the heart of how everything works in your computer, but you can't actually interface with it directly as a user. Programs that are designed to work with your OS can communicate with the kernel (Word, RStudio, Chrome, etc.), but if you want to do something outside of one of those programs you can't connect to the kernel directly yourself. That's where a shell comes in.
 
@@ -480,15 +480,7 @@ The quotes around the text can also be safely omitted in this case, but that isn
 ***
 
 
-## Additional Resources
-
-- [Brief Illustration of the Difference between Shell and Kernel](https://www.geeksforgeeks.org/difference-between-shell-and-kernel/)
-
-- [Reinforce Your New Knowledge through this Learning the Shell Page](https://linuxcommand.org/lc3_learning_the_shell.php)
-
-- Software Carpentries offers an open source course [introducing new users to the Unix Shell](https://swcarpentry.github.io/shell-novice/)
-
-### Getting help from the manual
+## Getting Help from the Manual
 
 <div class="warning">
 
@@ -507,6 +499,13 @@ When you want to exit the documentation, press the `Q` key on your keyboard to r
 
 ![Grep man command output with the full definition and some options displayed.](media/grep_output_large.png)
 
+## Additional Resources
+
+- [Brief Illustration of the Difference between Shell and Kernel](https://www.geeksforgeeks.org/difference-between-shell-and-kernel/)
+
+- [Reinforce Your New Knowledge through this Learning the Shell Page](https://linuxcommand.org/lc3_learning_the_shell.php)
+
+- Software Carpentries offers an open source course [introducing new users to the Unix Shell](https://swcarpentry.github.io/shell-novice/)
 
 ## Feedback
 


### PR DESCRIPTION
This addresses Issue https://github.com/arcus/education_modules/issues/213

The `man` command is not enabled in GitBash (and from the Git Bash conversation each time the issue is raised, is unlikely to every be available). This warning tells GitBash users that they can get the same info from an internet search.

I considered introducing `--help` here, but rejected it as it is far less helpful and has far less information than the manual, and the information provided is likely to be quite confusing for new users of Bash.