### PR TITLE
Highlight box update

### DIFF
--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -115,14 +115,14 @@ It has a gears icon and always begins with the text "Behind the scenes".
 For example:
 
 <div class = "behind-the-scenes">
-**Behind the scenes**
+<b style="color: rgb(var(--color-highlight));">Behind the scenes</b><br>
 
 The commit number is a hash and associated details
 
 </div>
 
 <div class = "behind-the-scenes">
-**Behind the scenes**
+<b style="color: rgb(var(--color-highlight));">Behind the scenes</b><br>
 
 In R the `<-` and `=` can both be used for assignment because...
 
@@ -135,14 +135,14 @@ It has a hand-holding-heart icon and always begins with the text "A little encou
 For example:
 
 <div class = "care">
-**A little encouragement...**
+<b style="color: rgb(var(--color-highlight));">A little encouragement...</b><br>
 
 This is a topic with a tremendous amount of jargon, which can make resources you may find online hard to understand for folks new to the field. When that happens it's easy to feel like there's something wrong with you if you don't get it, but that's not the case! Those kinds of gatekeeping explanations are a failure on the part of the writer, not the learner.
 
 </div>
 
 <div class = "care">
-**A little encouragement...**
+<b style="color: rgb(var(--color-highlight));">A little encouragement...</b><br>
 
 Feeling overwhelmed? It takes a long time to learn git, so don't be disheartened if it doesn't click initially. Just focus on stage, commit, and push. Ignore the rest for now, until you've had a chance to practice just the stage-commit-push process several times.
 
@@ -155,7 +155,7 @@ It has a brain icon and always begins with the text "Did you know?"
 For example:
 
 <div class = "cool-fact">
-**Did you know?**
+<b style="color: rgb(var(--color-highlight));">Did you know?</b><br>
 
 Functions like this are sometimes called "syntactic sugar" because they don't change anything about how the code runs, they just make it easier for humans to read, the way that sugar makes food sweeter without adding any nutrition.
 
@@ -163,7 +163,7 @@ Functions like this are sometimes called "syntactic sugar" because they don't ch
 
 
 <div class = "cool-fact">
-**Did you know?**
+<b style="color: rgb(var(--color-highlight));">Did you know?</b><br>
 
 This is a box showing how images work in a highlight box.
 
@@ -180,7 +180,7 @@ It has a circle-question icon and always begins with the text "Troubleshooting h
 For example:
 
 <div class = "help">
-**Troubleshooting help**
+<b style="color: rgb(var(--color-highlight));">Troubleshooting help</b><br>
 
 A common mistake when using `filter` is to write = when you mean ==. Remember that = is for argument assignment, and == is for testing equality in conditions. If you get them mixed up, your code won't run!
 
@@ -193,14 +193,14 @@ It has a clock-rotate-left icon and always begins with the text "Historical cont
 For example:
 
 <div class = "history">
-**Historical context**
+<b style="color: rgb(var(--color-highlight));">Historical context</b><br>
 
 The reason this command is named grep is...
 
 </div>
 
 <div class = "history">
-**Historical context**
+<b style="color: rgb(var(--color-highlight));">Historical context</b><br>
 
 The first README file was from 1971, etc.
 
@@ -214,7 +214,7 @@ It has a star icon and always begins with the text "Important note".
 For example:
 
 <div class = "important">
-**Important note**
+<b style="color: rgb(var(--color-highlight));">Important note</b><br>
 
 It's generally much easier to make any necessary changes to the dataframe, such as mutating variables, before sending it to the plotting command.
 
@@ -227,7 +227,7 @@ It has a book icon and always begins with the text "Learning connection".
 For example:
 
 <div class = "learn-more">
-**Learning connection**
+<b style="color: rgb(var(--color-highlight));">Learning connection</b><br>
 
 To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).
 
@@ -235,7 +235,7 @@ To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "
 
 
 <div class = "learn-more">
-**Learning connection**
+<b style="color: rgb(var(--color-highlight));">Learning connection</b><br>
 
 To do this in R instead of python, see [this other module](example.com).
 
@@ -249,14 +249,14 @@ It has a left-right arrow icon and always begins with the text "Another option".
 For example:
 
 <div class = "options">
-**Another option**
+<b style="color: rgb(var(--color-highlight));">Another option</b><br>
 
 You could also skip setting up an OSF account completely and just use github to publish and share your research products, but many people prefer to have OSF links available.
 
 </div>
 
 <div class = "options">
-**Another option**
+<b style="color: rgb(var(--color-highlight));">Another option</b><br>
 
 You can run this in the cloud or download all of the files locally and run it on your computer. If you run it on your computer, be sure to make note of which directory you save the files in and update your working directory accordingly.
 
@@ -269,14 +269,14 @@ It has a ! triangle icon and always begins with the text "Warning!".
 For example:
 
 <div class = "warning">
-**Warning!**
+<b style="color: rgb(var(--color-highlight));">Warning!</b><br>
 
 Double check your working directory before running this code. If you're in the wrong directory, you risk overwriting your files and losing all of your work with no way to recover it.
 
 </div>
 
 <div class = "warning">
-**Warning!**
+<b style="color: rgb(var(--color-highlight));">Warning!</b><br>
 
 Files uploaded to this account will be **publicly visible**. Be very careful not to upload anything with sensitive information like passwords or private data.
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -105,7 +105,7 @@ You can also include movies, audio, and any other embedded content in galleries 
 
 Include special notes with different formatting.
 
-Note: There's an additional style of highlight not listed here, "answer", that is used in [quizzes](#quiz).
+Note: There's an additional style of highlight not listed here, "answer", that is used in [quizzes](#quiz-quizzes).
 
 
 ### behind-the-scenes

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,8 +22,6 @@ After completion of this module, learners will be able to:
 
 @end
 
-@learn_more: <div class = "learnmore"><b style="color: rgb(var(--color-highlight))">Learning Connection</b> <br> @0 </div>
-
 link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
 
 script: https://kit.fontawesome.com/83b2343bd4.js
@@ -117,12 +115,14 @@ It has a gears icon and always begins with the text "Behind the scenes".
 For example:
 
 <div class = "behind-the-scenes">
+**Behind the scenes**
 
 The commit number is a hash and associated details
 
 </div>
 
 <div class = "behind-the-scenes">
+**Behind the scenes**
 
 In R the `<-` and `=` can both be used for assignment because...
 
@@ -135,12 +135,14 @@ It has a hand-holding-heart icon and always begins with the text "A little encou
 For example:
 
 <div class = "care">
+**A little encouragement...**
 
 This is a topic with a tremendous amount of jargon, which can make resources you may find online hard to understand for folks new to the field. When that happens it's easy to feel like there's something wrong with you if you don't get it, but that's not the case! Those kinds of gatekeeping explanations are a failure on the part of the writer, not the learner.
 
 </div>
 
 <div class = "care">
+**A little encouragement...**
 
 Feeling overwhelmed? It takes a long time to learn git, so don't be disheartened if it doesn't click initially. Just focus on stage, commit, and push. Ignore the rest for now, until you've had a chance to practice just the stage-commit-push process several times.
 
@@ -153,20 +155,15 @@ It has a brain icon and always begins with the text "Did you know?"
 For example:
 
 <div class = "cool-fact">
+**Did you know?**
 
 Functions like this are sometimes called "syntactic sugar" because they don't change anything about how the code runs, they just make it easier for humans to read, the way that sugar makes food sweeter without adding any nutrition.
 
 </div>
 
-<div class = "cool-fact">
-
-![Carebear stare.](https://media.giphy.com/media/11z8mwhw0jxQiI/giphy.gif)
-
-This is a box showing how images work in a highlight box.
-
-</div>
 
 <div class = "cool-fact">
+**Did you know?**
 
 This is a box showing how images work in a highlight box.
 
@@ -183,6 +180,7 @@ It has a circle-question icon and always begins with the text "Troubleshooting h
 For example:
 
 <div class = "help">
+**Troubleshooting help**
 
 A common mistake when using `filter` is to write = when you mean ==. Remember that = is for argument assignment, and == is for testing equality in conditions. If you get them mixed up, your code won't run!
 
@@ -195,12 +193,14 @@ It has a clock-rotate-left icon and always begins with the text "Historical cont
 For example:
 
 <div class = "history">
+**Historical context**
 
 The reason this command is named grep is...
 
 </div>
 
 <div class = "history">
+**Historical context**
 
 The first README file was from 1971, etc.
 
@@ -214,6 +214,7 @@ It has a star icon and always begins with the text "Important note".
 For example:
 
 <div class = "important">
+**Important note**
 
 It's generally much easier to make any necessary changes to the dataframe, such as mutating variables, before sending it to the plotting command.
 
@@ -226,6 +227,7 @@ It has a book icon and always begins with the text "Learning connection".
 For example:
 
 <div class = "learn-more">
+**Learning connection**
 
 To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).
 
@@ -233,32 +235,12 @@ To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "
 
 
 <div class = "learn-more">
+**Learning connection**
 
 To do this in R instead of python, see [this other module](example.com).
 
 </div>
 
-@learn_more(
-  To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).
-  )
-
-
-
-Can we add a list?
-
-- first
-- second
-
-@learn_more(``Try some code `function`.``)
-
-@learn_more(
-  Here's the first part.
-
-  This should be a new **paragraph**.
-  )
-
-
-@learn_more0
 
 ### options
 
@@ -267,12 +249,14 @@ It has a left-right arrow icon and always begins with the text "Another option".
 For example:
 
 <div class = "options">
+**Another option**
 
 You could also skip setting up an OSF account completely and just use github to publish and share your research products, but many people prefer to have OSF links available.
 
 </div>
 
 <div class = "options">
+**Another option**
 
 You can run this in the cloud or download all of the files locally and run it on your computer. If you run it on your computer, be sure to make note of which directory you save the files in and update your working directory accordingly.
 
@@ -285,12 +269,14 @@ It has a ! triangle icon and always begins with the text "Warning!".
 For example:
 
 <div class = "warning">
+**Warning!**
 
 Double check your working directory before running this code. If you're in the wrong directory, you risk overwriting your files and losing all of your work with no way to recover it.
 
 </div>
 
 <div class = "warning">
+**Warning!**
 
 Files uploaded to this account will be **publicly visible**. Be very careful not to upload anything with sensitive information like passwords or private data.
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,8 +22,8 @@ After completion of this module, learners will be able to:
 
 @end
 
-@learn_more: <div class = "learn-more">@0</div>
-@highlight: <b style="color: red">@0</b>
+@learn_more: <div class = "learn-more"> <b>Header Text</b> <br> @0</div>
+
 
 link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
 
@@ -239,9 +239,7 @@ To do this in R instead of python, see [this other module](example.com).
 
 </div>
 
-@learn_more(Testing macro box)
-
-@highlight(Another macro test)
+@learn_more(To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).)
 
 ### options
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,10 +22,7 @@ After completion of this module, learners will be able to:
 
 @end
 
-@learn_more
-<div class = "learn-more"> <b>Block Header Text</b> <br> @0</div>
-@end
-
+@learn_more: <div class = "learnmore"><b style="color: rgb(var(--color-highlight))">Learning Connection</b> <br> @0 </div>
 
 link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
 
@@ -241,14 +238,27 @@ To do this in R instead of python, see [this other module](example.com).
 
 </div>
 
-@learn_more(To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).
-
-I'm adding a list
-- one
-- two
+@learn_more(
+  To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).
+  )
 
 
-)
+
+Can we add a list?
+
+- first
+- second
+
+@learn_more(``Try some code `function`.``)
+
+@learn_more(
+  Here's the first part.
+
+  This should be a new **paragraph**.
+  )
+
+
+@learn_more0
 
 ### options
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,7 +22,7 @@ After completion of this module, learners will be able to:
 
 @end
 
-link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles-test.css
+link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
 
 script: https://kit.fontawesome.com/83b2343bd4.js
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -3,7 +3,7 @@
 author:   Your Name
 email:    email@chop.edu
 version:  0.0.0
-module_template_version: 3.0.0
+module_template_version: 3.1.0
 language: en
 narrator: UK English Female
 title: Module Title

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -156,6 +156,23 @@ Functions like this are sometimes called "syntactic sugar" because they don't ch
 
 </div>
 
+<div class = "cool-fact">
+
+![Carebear stare.](https://media.giphy.com/media/11z8mwhw0jxQiI/giphy.gif)
+
+This is a box showing how images work in a highlight box.
+
+</div>
+
+<div class = "cool-fact">
+
+This is a box showing how images work in a highlight box.
+
+![Carebear team.](https://media.giphy.com/media/W256ghnG9iV8I/giphy.gif)
+
+
+</div>
+
 
 ### help
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -2,8 +2,8 @@
 
 author:   Your Name
 email:    email@chop.edu
-version:  0.0.2
-module_template_version: 2.0.1
+version:  0.0.0
+module_template_version: 3.0.0
 language: en
 narrator: UK English Female
 title: Module Title

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -23,7 +23,7 @@ After completion of this module, learners will be able to:
 @end
 
 @learn_more
-<div class = "learn-more"> <b>Header Text</b> <br> @0</div>
+<div class = "learn-more"> <b>Block Header Text</b> <br> @0</div>
 @end
 
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,7 +22,8 @@ After completion of this module, learners will be able to:
 
 @end
 
-@learn-more: <div class = "learn-more">@0</div>
+@learn_more: <div class = "learn-more">@0</div>
+@highlight: <b style="color: red">@0</b>
 
 link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
 
@@ -238,7 +239,9 @@ To do this in R instead of python, see [this other module](example.com).
 
 </div>
 
-@learn-more(Testing macro box)
+@learn_more(Testing macro box)
+
+@highlight(Another macro test)
 
 ### options
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,7 +22,9 @@ After completion of this module, learners will be able to:
 
 @end
 
-@learn_more: <div class = "learn-more"> <b>Header Text</b> <br> @0</div>
+@learn_more
+<div class = "learn-more"> <b>Header Text</b> <br> @0</div>
+@end
 
 
 link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
@@ -239,7 +241,14 @@ To do this in R instead of python, see [this other module](example.com).
 
 </div>
 
-@learn_more(To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).)
+@learn_more(To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).
+
+I'm adding a list
+- one
+- two
+
+
+)
 
 ### options
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,6 +22,8 @@ After completion of this module, learners will be able to:
 
 @end
 
+@learn-more: <div class = "learn-more">@0</div>
+
 link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
 
 script: https://kit.fontawesome.com/83b2343bd4.js
@@ -235,6 +237,8 @@ To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "
 To do this in R instead of python, see [this other module](example.com).
 
 </div>
+
+@learn-more(Testing macro box)
 
 ### options
 

--- a/a_sample_module_template/a_sample_module_template.md
+++ b/a_sample_module_template/a_sample_module_template.md
@@ -22,7 +22,7 @@ After completion of this module, learners will be able to:
 
 @end
 
-link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
+link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles-test.css
 
 script: https://kit.fontawesome.com/83b2343bd4.js
 
@@ -103,48 +103,157 @@ You can also include movies, audio, and any other embedded content in galleries 
 
 ## Including highlight boxes
 
-Include special notes with different formatting. The style "important" is for important points and key ideas. For example:
+Include special notes with different formatting.
 
-<div class = "important">
-Tip: It's generally much easier to make any necessary changes to the dataframe, such as mutating variables, before sending it to the plotting command.
+Note: There's an additional style of highlight not listed here, "answer", that is used in [quizzes](#quiz).
+
+
+### behind-the-scenes
+
+The style "behind-the-scenes" is for giving a little more technical detail about how something does what it does.
+It has a gears icon and always begins with the text "Behind the scenes".
+For example:
+
+<div class = "behind-the-scenes">
+
+The commit number is a hash and associated details
+
 </div>
 
-The style "care" is for content related to compassion, self-care, and motivation. For example:
+<div class = "behind-the-scenes">
+
+In R the `<-` and `=` can both be used for assignment because...
+
+</div>
+
+### care
+
+The style "care" is for content related to compassion, self-care, and motivation. For more technical help or troubleshooting, use "help" instead.
+It has a hand-holding-heart icon and always begins with the text "A little encouragement..."
+For example:
 
 <div class = "care">
+
 This is a topic with a tremendous amount of jargon, which can make resources you may find online hard to understand for folks new to the field. When that happens it's easy to feel like there's something wrong with you if you don't get it, but that's not the case! Those kinds of gatekeeping explanations are a failure on the part of the writer, not the learner.
+
+</div>
+
+<div class = "care">
+
+Feeling overwhelmed? It takes a long time to learn git, so don't be disheartened if it doesn't click initially. Just focus on stage, commit, and push. Ignore the rest for now, until you've had a chance to practice just the stage-commit-push process several times.
+
+</div>
+
+### cool-fact
+
+The style "cool-fact" is for any cool fact that really doesn't fit into any of our other categories.
+It has a brain icon and always begins with the text "Did you know?"
+For example:
+
+<div class = "cool-fact">
+
+Functions like this are sometimes called "syntactic sugar" because they don't change anything about how the code runs, they just make it easier for humans to read, the way that sugar makes food sweeter without adding any nutrition.
+
 </div>
 
 
-The style "help" is for educational first aid --- "help I'm lost!" suggestions. For example:
+### help
+
+The style "help" is for troubleshooting help, common errors, and specific technical problems. If you want to emphasize a very serious potential problem, use "warning" instead. For support that is more psycho/emotional or meta-learning in nature, use "care" instead.
+It has a circle-question icon and always begins with the text "Troubleshooting help".
+For example:
 
 <div class = "help">
-Feeling overwhelmed? It takes a long time to learn git, so don't be disheartened if it doesn't click initially. Just focus on stage, commit, and push. Ignore the rest for now, until you've had a chance to practice just the stage-commit-push process several times.
+
+A common mistake when using `filter` is to write = when you mean ==. Remember that = is for argument assignment, and == is for testing equality in conditions. If you get them mixed up, your code won't run!
+
 </div>
 
-The style "warning" alerts users to potential pitfalls. For example:
+### history
+
+The style "history" is for more historical context about how/when/why something came to be the way it currently is.
+It has a clock-rotate-left icon and always begins with the text "Historical context".
+For example:
+
+<div class = "history">
+
+The reason this command is named grep is...
+
+</div>
+
+<div class = "history">
+
+The first README file was from 1971, etc.
+
+</div>
+
+
+### important
+
+The style "important" is for important points and key ideas.
+It has a star icon and always begins with the text "Important note".
+For example:
+
+<div class = "important">
+
+It's generally much easier to make any necessary changes to the dataframe, such as mutating variables, before sending it to the plotting command.
+
+</div>
+
+### learn-more
+
+The style "learn-more" alerts users resources for further learning, especially links to a more in-depth discussion of an issue that might be touched on only briefly in the module. It can link to outside sources, or other modules by us.
+It has a book icon and always begins with the text "Learning connection".
+For example:
+
+<div class = "learn-more">
+
+To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf).
+
+</div>
+
+
+<div class = "learn-more">
+
+To do this in R instead of python, see [this other module](example.com).
+
+</div>
+
+### options
+
+The style "options" is for an aside to let learners know there's another possible approach. This is for short explanations rather than linked resources; to link to another approach (e.g. here's a tutorial for another way to do this), use "learn-more" instead.
+It has a left-right arrow icon and always begins with the text "Another option".
+For example:
+
+<div class = "options">
+
+You could also skip setting up an OSF account completely and just use github to publish and share your research products, but many people prefer to have OSF links available.
+
+</div>
+
+<div class = "options">
+
+You can run this in the cloud or download all of the files locally and run it on your computer. If you run it on your computer, be sure to make note of which directory you save the files in and update your working directory accordingly.
+
+</div>
+
+### warning
+
+The style "warning" alerts users to potential pitfalls, and should be reserved for serious problems only. For less serious problems, use "help" instead.
+It has a ! triangle icon and always begins with the text "Warning!".
+For example:
 
 <div class = "warning">
-A common mistake when using `filter` is to write = when you mean ==. Remember that = is for argument assignment, and == is for testing equality in conditions. If you get them mixed up, your code won't run!
+
+Double check your working directory before running this code. If you're in the wrong directory, you risk overwriting your files and losing all of your work with no way to recover it.
+
 </div>
 
-The style "learnmore" alerts users resources for further learning, especially links to a more in-depth discussion of an issue that might be touched on only briefly in the module.
+<div class = "warning">
 
-<div class = "learnmore">
-To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf)
+Files uploaded to this account will be **publicly visible**. Be very careful not to upload anything with sensitive information like passwords or private data.
+
 </div>
-
-The style "options" is for an aside to let learners know there's another possible approach. For example:
-
-<div class = "options">
-You could also skip setting up an OSF account completely and just use github to publish and share your research products, but many people prefer to have OSF links available.
-</div>
-or
-<div class = "options">
-To do this in R instead of python, see this other module.
-</div>
-
-There's an additional style of highlight, "answer", that is used in [quizzes](#quiz).
 
 ## Including math
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -55,150 +55,52 @@ h2, h3, h4 {
   color: rgb(var(--color-highlight));
 }
 
-.answer span:first-child:before,
-.behind-the-scenes span:first-child:before,
-.care span:first-child:before,
-.cool-fact span:first-child:before,
-.help span:first-child:before,
-.history span:first-child:before,
-.important span:first-child:before,
-.learn-more span:first-child:before,
-.options span:first-child:before,
-.warning span:first-child:before,
-.answer p:first-child:before,
-.behind-the-scenes p:first-child:before,
-.care p:first-child:before,
-.cool-fact p:first-child:before,
-.help p:first-child:before,
-.history p:first-child:before,
-.important p:first-child:before,
-.learn-more p:first-child:before,
-.options p:first-child:before,
-.warning p:first-child:before,
-.answer figure:first-child:before,
-.behind-the-scenes figure:first-child:before,
-.care figure:first-child:before,
-.cool-fact figure:first-child:before,
-.help figure:first-child:before,
-.history figure:first-child:before,
-.important figure:first-child:before,
-.learn-more figure:first-child:before,
-.options figure:first-child:before,
-.warning figure:first-child:before
-{
-  white-space: pre;
-  font-weight: bold;
-  color: rgb(var(--color-highlight));
-}
 
 .answer:before {
   content: "\f058";
 }
 
-.answer p:first-child:before,
-.answer span:first-child:before,
-.answer figure:first-child:before {
-  content: "Solution \A\A";
-  white-space: pre;
-}
 
 .behind-the-scenes:before {
   content: "\f085";
 }
 
-.behind-the-scenes p:first-child:before,
-.behind-the-scenes span:first-child:before,
-.behind-the-scenes figure:first-child:before {
-  content: "Behind the scenes \A\A";
-  white-space: pre;
-}
 
 .care:before {
   content: "\f4be";
-}
-
-.care p:first-child:before,
-.care span:first-child:before,
-.care figure:first-child:before {
-  content: "A little encouragement \A\A";
-  white-space: pre;
 }
 
 .cool-fact:before {
   content: "\f5dc";
 }
 
-.cool-fact p:first-child:before,
-.cool-fact span:first-child:before,
-.cool-fact figure:first-child:before {
-  content: "Did you know? \A\A";
-  white-space: pre;
-}
 
 .help:before {
   content: "\f059";
-}
-
-.help p:first-child:before,
-.help span:first-child:before,
-.help figure:first-child:before {
-  content: "Troubleshooting help \A\A";
-  white-space: pre;
 }
 
 .history:before {
   content: "\f1da";
 }
 
-.history p:first-child:before,
-.history span:first-child:before,
-.history figure:first-child:before {
-  content: "Historical context \A\A";
-  white-space: pre;
-}
 
 .important:before {
   content: "\f005";
 }
 
-.important p:first-child:before,
-.important span:first-child:before,
-.important figure:first-child:before {
-  content: "Important note \A\A";
-  white-space: pre;
-}
 
 .learn-more:before {
   content: "\f518";
 }
 
-.learn-more p:first-child:before,
-.learn-more span:first-child:before,
-.learn-more figure:first-child:before {
-  content: "Learning connection \A\A";
-  white-space: pre;
-}
 
 .options:before {
   content: "\f337";
 }
 
-.options p:first-child:before,
-.options span:first-child:before,
-.options figure:first-child:before {
-  content: "Another option \A\A";
-  white-space: pre;
-}
 
 .warning:before {
   content: "\f071";
-}
-
-.warning p:first-child:before, 
-.warning span:first-child:before,
-.warning figure:first-child:before {
-  content: "Warning! \A\A";
-  white-space: pre;
 }
 
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -17,14 +17,17 @@ h2, h3, h4 {
   -webkit-font-smoothing: antialiased;
 }
 
-.important,
+
 .answer,
-.warning,
+.behind-the-scenes,
+.care,
+.cool-fact,
+.help,
+.history,
+.important,
 .learnmore,
 .options,
-.help,
-.care,
-.hint
+.warning
 {
   position: relative;
   padding: 1em 1em 1em 1em;
@@ -34,55 +37,123 @@ h2, h3, h4 {
   width = 100%;
 }
 
-.important:before,
 .answer:before,
-.warning:before,
+.behind-the-scenes:before,
+.care:before,
+.cool-fact:before,
+.help:before,
+.history:before,
+.important:before,
 .learnmore:before,
 .options:before,
-.help:before,
-.care:before,
-.hint:before
+.warning:before
 {
   display: table-cell;
   vertical-align: middle;
   padding: inherit;
-  font-family: "Font Awesome 5 Free";
+  font-family: "Font Awesome 6 Free";
   font-weight: 900;
   font-size: 2.5em;
   color: rgb(var(--color-highlight));
+}
+
+.answer span:before,
+.behind-the-scenes span:before,
+.care span:before,
+.cool-fact span:before,
+.help span:before,
+.history span:before,
+.important span:before,
+.learnmore span:before,
+.options span:before,
+.warning span:before
+{
+  white-space: pre;
+  font-weight: bold;
+  color: rgb(var(--color-highlight));
+}
+
+
+.answer:before {
+  content: "\f058";
+}
+
+.answer span:before {
+  content: "Solution \A\A";
+}
+
+.behind-the-scenes:before {
+  content: "\f085";
+}
+
+.behind-the-scenes span:before {
+  content: "Behind the scenes \A\A";
+}
+
+.care:before {
+  content: "\f4be";
+}
+
+.care span:before {
+  content: "A little encouragement \A\A";
+}
+
+.cool-fact:before {
+  content: "\f6b8";
+}
+
+.cool-fact span:before {
+  content: "Did you know? \A\A";
+}
+
+.help:before {
+  content: "\f059";
+}
+
+.help span:before {
+  content: "Troubleshooting help \A\A";
+}
+
+.history:before {
+  content: "\f0ac";
+}
+
+.history span:before {
+  content: "Historical context \A\A";
 }
 
 .important:before {
   content: "\f005";
 }
 
-.answer:before {
-  content: "\f058";
-}
-
-.warning:before {
-  content: "\f1e2";
+.important span:before {
+  content: "Important note \A\A";
 }
 
 .learnmore:before {
-  content: "\f4fb";
+  content: "\fe0c0";
+}
+
+.learnmore span:before {
+  content: "Learning connection \A\A";
 }
 
 .options:before {
-  content: "\f24e";
+  content: "\f337";
 }
 
-.help:before {
-  content: "\f479";
+.options span:before {
+  content: "Another option \A\A";
 }
 
-.care:before {
-  content: "\f004";
+.warning:before {
+  content: "\f071";
 }
 
-.hint:before {
-  content: "\f0eb";
+.warning span:before {
+  content: "Warning! \A\A";
 }
+
 
 .lia_header__logo {
   display: none;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -99,7 +99,7 @@ h2, h3, h4 {
 }
 
 .cool-fact:before {
-  content: "\f6b8";
+  content: "\f5dc";
 }
 
 .cool-fact span:before {
@@ -115,7 +115,7 @@ h2, h3, h4 {
 }
 
 .history:before {
-  content: "\f0ac";
+  content: "\f1da";
 }
 
 .history span:before {
@@ -131,7 +131,7 @@ h2, h3, h4 {
 }
 
 .learnmore:before {
-  content: "\fe0c0";
+  content: "\f518";
 }
 
 .learnmore span:before {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -19,13 +19,13 @@ h2, h3, h4 {
 
 
 .answer,
-.behindthescenes,
+.behind-the-scenes,
 .care,
-.coolfact,
+.cool-fact,
 .help,
 .history,
 .important,
-.learnmore,
+.learn-more,
 .options,
 .warning
 {
@@ -38,13 +38,13 @@ h2, h3, h4 {
 }
 
 .answer:before,
-.behindthescenes:before,
+.behind-the-scenes:before,
 .care:before,
-.coolfact:before,
+.cool-fact:before,
 .help:before,
 .history:before,
 .important:before,
-.learnmore:before,
+.learn-more:before,
 .options:before,
 .warning:before
 {
@@ -58,13 +58,13 @@ h2, h3, h4 {
 }
 
 .answer span:before,
-.behindthescenes span:before,
+.behind-the-scenes span:before,
 .care span:before,
-.coolfact span:before,
+.cool-fact span:before,
 .help span:before,
 .history span:before,
 .important span:before,
-.learnmore span:before,
+.learn-more span:before,
 .options span:before,
 .warning span:before
 {
@@ -82,11 +82,11 @@ h2, h3, h4 {
   content: "Solution \A\A";
 }
 
-.behindthescenes:before {
+.behind-the-scenes:before {
   content: "\f085";
 }
 
-.behindthescenes span:before {
+.behind-the-scenes span:before {
   content: "Behind the scenes \A\A";
 }
 
@@ -98,11 +98,11 @@ h2, h3, h4 {
   content: "A little encouragement \A\A";
 }
 
-.coolfact:before {
+.cool-fact:before {
   content: "\f5dc";
 }
 
-.coolfact span:before {
+.cool-fact span:before {
   content: "Did you know? \A\A";
 }
 
@@ -130,11 +130,11 @@ h2, h3, h4 {
   content: "Important note \A\A";
 }
 
-.learnmore:before {
+.learn-more:before {
   content: "\f518";
 }
 
-.learnmore span:before {
+.learn-more span:before {
   content: "Learning connection \A\A";
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -74,7 +74,17 @@ h2, h3, h4 {
 .important p:first-child:before,
 .learn-more p:first-child:before,
 .options p:first-child:before,
-.warning p:first-child:before
+.warning p:first-child:before,
+.answer figure:first-child:before,
+.behind-the-scenes figure:first-child:before,
+.care figure:first-child:before,
+.cool-fact figure:first-child:before,
+.help figure:first-child:before,
+.history figure:first-child:before,
+.important figure:first-child:before,
+.learn-more figure:first-child:before,
+.options figure:first-child:before,
+.warning figure:first-child:before
 {
   white-space: pre;
   font-weight: bold;
@@ -85,7 +95,9 @@ h2, h3, h4 {
   content: "\f058";
 }
 
-.answer p:first-child:before, .answer span:first-child:before {
+.answer p:first-child:before,
+.answer span:first-child:before,
+.answer figure:first-child:before {
   content: "Solution \A\A";
   white-space: pre;
 }
@@ -94,7 +106,9 @@ h2, h3, h4 {
   content: "\f085";
 }
 
-.behind-the-scenes p:first-child:before, .behind-the-scenes span:first-child:before {
+.behind-the-scenes p:first-child:before,
+.behind-the-scenes span:first-child:before,
+.behind-the-scenes figure:first-child:before {
   content: "Behind the scenes \A\A";
   white-space: pre;
 }
@@ -103,7 +117,9 @@ h2, h3, h4 {
   content: "\f4be";
 }
 
-.care p:first-child:before, .care span:first-child:before {
+.care p:first-child:before,
+.care span:first-child:before,
+.care figure:first-child:before {
   content: "A little encouragement \A\A";
   white-space: pre;
 }
@@ -112,7 +128,9 @@ h2, h3, h4 {
   content: "\f5dc";
 }
 
-.cool-fact p:first-child:before, .cool-fact span:first-child:before {
+.cool-fact p:first-child:before,
+.cool-fact span:first-child:before,
+.cool-fact figure:first-child:before {
   content: "Did you know? \A\A";
   white-space: pre;
 }
@@ -121,7 +139,9 @@ h2, h3, h4 {
   content: "\f059";
 }
 
-.help p:first-child:before, .help span:first-child:before {
+.help p:first-child:before,
+.help span:first-child:before,
+.help figure:first-child:before {
   content: "Troubleshooting help \A\A";
   white-space: pre;
 }
@@ -130,7 +150,9 @@ h2, h3, h4 {
   content: "\f1da";
 }
 
-.history p:first-child:before, .history span:first-child:before {
+.history p:first-child:before,
+.history span:first-child:before,
+.history figure:first-child:before {
   content: "Historical context \A\A";
   white-space: pre;
 }
@@ -139,7 +161,9 @@ h2, h3, h4 {
   content: "\f005";
 }
 
-.important p:first-child:before, .important span:first-child:before {
+.important p:first-child:before,
+.important span:first-child:before,
+.important figure:first-child:before {
   content: "Important note \A\A";
   white-space: pre;
 }
@@ -148,7 +172,9 @@ h2, h3, h4 {
   content: "\f518";
 }
 
-.learn-more p:first-child:before, .learn-more span:first-child:before {
+.learn-more p:first-child:before,
+.learn-more span:first-child:before,
+.learn-more figure:first-child:before {
   content: "Learning connection \A\A";
   white-space: pre;
 }
@@ -157,7 +183,9 @@ h2, h3, h4 {
   content: "\f337";
 }
 
-.options p:first-child:before, .options span:first-child:before {
+.options p:first-child:before,
+.options span:first-child:before,
+.options figure:first-child:before {
   content: "Another option \A\A";
   white-space: pre;
 }
@@ -166,7 +194,9 @@ h2, h3, h4 {
   content: "\f071";
 }
 
-.warning p:first-child:before, .warning span:first-child:before {
+.warning p:first-child:before, 
+.warning span:first-child:before,
+.warning figure:first-child:before {
   content: "Warning! \A\A";
   white-space: pre;
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -55,101 +55,120 @@ h2, h3, h4 {
   color: rgb(var(--color-highlight));
 }
 
-.answer span:before,
-.behind-the-scenes span:before,
-.care span:before,
-.cool-fact span:before,
-.help span:before,
-.history span:before,
-.important span:before,
-.learn-more span:before,
-.options span:before,
-.warning span:before
+.answer span:first-child:before,
+.behind-the-scenes span:first-child:before,
+.care span:first-child:before,
+.cool-fact span:first-child:before,
+.help span:first-child:before,
+.history span:first-child:before,
+.important span:first-child:before,
+.learn-more span:first-child:before,
+.options span:first-child:before,
+.warning span:first-child:before,
+.answer p:first-child:before,
+.behind-the-scenes p:first-child:before,
+.care p:first-child:before,
+.cool-fact p:first-child:before,
+.help p:first-child:before,
+.history p:first-child:before,
+.important p:first-child:before,
+.learn-more p:first-child:before,
+.options p:first-child:before,
+.warning p:first-child:before
 {
   white-space: pre;
   font-weight: bold;
   color: rgb(var(--color-highlight));
 }
 
-
 .answer:before {
   content: "\f058";
 }
 
-.answer span:before {
+.answer p:first-child:before, .answer span:first-child:before {
   content: "Solution \A\A";
+  white-space: pre;
 }
 
 .behind-the-scenes:before {
   content: "\f085";
 }
 
-.behind-the-scenes span:before {
+.behind-the-scenes p:first-child:before, .behind-the-scenes span:first-child:before {
   content: "Behind the scenes \A\A";
+  white-space: pre;
 }
 
 .care:before {
   content: "\f4be";
 }
 
-.care span:before {
+.care p:first-child:before, .care span:first-child:before {
   content: "A little encouragement \A\A";
+  white-space: pre;
 }
 
 .cool-fact:before {
   content: "\f5dc";
 }
 
-.cool-fact span:before {
+.cool-fact p:first-child:before, .cool-fact span:first-child:before {
   content: "Did you know? \A\A";
+  white-space: pre;
 }
 
 .help:before {
   content: "\f059";
 }
 
-.help span:before {
+.help p:first-child:before, .help span:first-child:before {
   content: "Troubleshooting help \A\A";
+  white-space: pre;
 }
 
 .history:before {
   content: "\f1da";
 }
 
-.history span:before {
+.history p:first-child:before, .history span:first-child:before {
   content: "Historical context \A\A";
+  white-space: pre;
 }
 
 .important:before {
   content: "\f005";
 }
 
-.important span:before {
+.important p:first-child:before, .important span:first-child:before {
   content: "Important note \A\A";
+  white-space: pre;
 }
 
 .learn-more:before {
   content: "\f518";
 }
 
-.learn-more span:before {
+.learn-more p:first-child:before, .learn-more span:first-child:before {
   content: "Learning connection \A\A";
+  white-space: pre;
 }
 
 .options:before {
   content: "\f337";
 }
 
-.options span:before {
+.options p:first-child:before, .options span:first-child:before {
   content: "Another option \A\A";
+  white-space: pre;
 }
 
 .warning:before {
   content: "\f071";
 }
 
-.warning span:before {
+.warning p:first-child:before, .warning span:first-child:before {
   content: "Warning! \A\A";
+  white-space: pre;
 }
 
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -9,10 +9,9 @@ h2, h3, h4 {
 }
 
 /* general info about how icons should render (see https://fontawesome.com/v5.15/how-to-use/on-the-web/advanced/css-pseudo-elements) */
+/* upgraded to 6 https://fontawesome.com/docs/web/setup/upgrade/pseudo-elements#contentHeader */
 .icon::before {
   display: inline-block;
-  font-style: normal;
-  font-variant: normal;
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
 }
@@ -51,8 +50,7 @@ h2, h3, h4 {
   display: table-cell;
   vertical-align: middle;
   padding: inherit;
-  font-family: "Font Awesome 6 Free";
-  font-weight: 900;
+  font: var(--fa-font-solid);
   font-size: 2.5em;
   color: rgb(var(--color-highlight));
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -19,9 +19,9 @@ h2, h3, h4 {
 
 
 .answer,
-.behind-the-scenes,
+.behindthescenes,
 .care,
-.cool-fact,
+.coolfact,
 .help,
 .history,
 .important,
@@ -38,9 +38,9 @@ h2, h3, h4 {
 }
 
 .answer:before,
-.behind-the-scenes:before,
+.behindthescenes:before,
 .care:before,
-.cool-fact:before,
+.coolfact:before,
 .help:before,
 .history:before,
 .important:before,
@@ -58,9 +58,9 @@ h2, h3, h4 {
 }
 
 .answer span:before,
-.behind-the-scenes span:before,
+.behindthescenes span:before,
 .care span:before,
-.cool-fact span:before,
+.coolfact span:before,
 .help span:before,
 .history span:before,
 .important span:before,
@@ -82,11 +82,11 @@ h2, h3, h4 {
   content: "Solution \A\A";
 }
 
-.behind-the-scenes:before {
+.behindthescenes:before {
   content: "\f085";
 }
 
-.behind-the-scenes span:before {
+.behindthescenes span:before {
   content: "Behind the scenes \A\A";
 }
 
@@ -98,11 +98,11 @@ h2, h3, h4 {
   content: "A little encouragement \A\A";
 }
 
-.cool-fact:before {
+.coolfact:before {
   content: "\f5dc";
 }
 
-.cool-fact span:before {
+.coolfact span:before {
   content: "Did you know? \A\A";
 }
 

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -125,7 +125,7 @@ Some common options are to ask for only some of this metadata using flags:
 - `wc -m` returns the number of characters followed by the file's name.
 
 
-<div class = "learnmore">
+<div class = "learn-more">
 
 **Words**   
 
@@ -199,7 +199,7 @@ You can change how the lines are ordered using flags. The `-r` flag reverses the
 ```
 sort -r Animals.csv
 ```
-<div class ="learnmore">
+<div class ="learn-more">
 
 There are lots of options for the `sort` command. All of the options are visible in the manual which you can see by typing `man sort`. In addition to reversing the order with `-r`, a few particularly useful ones include:
 
@@ -241,7 +241,7 @@ sort Animals.csv >> animals.txt
 
 Again there is no output shown because it was redirected into the file `animals.txt`. Check that `animals.txt` now contains the word count at the top, followed by a sorted copy of the data from `Animals.csv`.
 
-<div class = "learnmore">
+<div class = "learn-more">
 
 In the Bash language, right arrows `>` redirect output, and left arrows `<` redirect input. You are unlikely to need to redirect input since most of the time just entering the input you want, like `Animals.csv`, is sufficient. However if you end up writing more complicated pipelines in the future it may be useful to [learn more about redirecting input](https://www.gnu.org/software/bash/manual/html_node/Redirections.html)
 
@@ -405,7 +405,7 @@ wc -m *.txt | sort -n | head -1
 ```
 The Indian cobra, scientific name _Naja naja_ has the shortest character count of any of the animals listed here.
 
-<div class = "learnmore">
+<div class = "learn-more">
 
 **Why is the character count for `Naja naja` 10?**
 

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -70,7 +70,7 @@ On a Mac computer, bash has been the default login shell in the **Terminal** com
 
 2. The terminal may take a few seconds to start, once it is open you should see a blinking cursor where you can type.
 
-<div class = "learnmore">
+<div class = "learn-more">
 It should be noted that Macs with the Catalina Operating System or later are running zsh instead of bash. That said, zsh is [functionally a later and greater version of bash with some key differences noted](https://medium.com/@harrison.miller13_28580/bash-vs-z-shell-a-tale-of-two-command-line-shells-c65bb66e4658).
 </div>
 
@@ -116,7 +116,7 @@ Your computer has an **Operating System** (OS), most commonly either Windows, Ma
 
 The **shell** is like a layer outside the kernel that you as a user can communicate with. You can type commands in the shell, and it will execute them for you in the kernel. Back when computers were newer and there were few ready programs available, the shell was the primary way to get stuff done on a computer.
 
-<div class = "learnmore">
+<div class = "learn-more">
 To learn more, check out this post for [an excellent breakdown of the difference between the shell and the kernel](https://www.geeksforgeeks.org/difference-between-shell-and-kernel/).
 </div>
 
@@ -260,7 +260,7 @@ The bash shell can see and move files of all types, but it is most useful for in
 
 A [**plain text**](https://en.wikipedia.org/wiki/Plain_text) file is a file that contains only text characters like the ones you can type directly using your keyboard. For example the words "plain text" at the beginning of this paragraph, which are both bolded and hyperlinked, are not being presented to you as plain text. You might have run into problems with files that aren't in plain text if, for example, you ever opened a file in a new program and lost some of the formatting like particular fonts in Word or conditional highlighting in Excel.
 
-<div class = "learnmore">
+<div class = "learn-more">
 Even though the words "plain text" in the previous paragraph have some non-text attributes, they are all recorded as plain text in the Markdown (`.md`) file of this lesson. If you open the [Markdown file](link/to/git/of/this/file), you will see only characters that can be typed by a keyboard:
 
 ```
@@ -287,7 +287,7 @@ Some common types of plain text files you might have seen before are:
 | `.md` | markdown file |
 | `.html` | html file |
 
-<div class = "learnmore">
+<div class = "learn-more">
 The file endings (or **extensions**) like `.txt`, `.csv`, `.doc` (Word), or `.xslx` (Excel) are the part of the file name that lets your computer know what type of program to use to open it. The ending doesn't actually impact the contents of the file, which is why we will be able to create files like `my_file` in the next section with no file ending at all.
 </div>
 
@@ -389,7 +389,7 @@ Give it a try:
 cat my_sentences
 ```
 
-<div class = "learnmore">
+<div class = "learn-more">
 The command `cat` is very powerful three-part function that allows a reader to view, combine, or create a new version of a file. In fact `cat` is a shortening of the word "con**cat**enate."
 </div>
 

--- a/bash_command_line_102/bash_command_line_102.md
+++ b/bash_command_line_102/bash_command_line_102.md
@@ -146,7 +146,7 @@ We could continue to individually look at the contents of each file, but that is
 
 
 
-<div class ="learnmore">
+<div class ="learn-more">
 Files that start with a `.` (period) are hidden when you enter `ls`. These are usually operational files that help navigate the file system or keep track of metadata. To see all of these files, enter `ls -a`. The `-a` flag tells bash to show you all files and folders.
 
 Since you just downloaded this folder from `GitHub`, you should see `.git` which keeps track of changes to this public directory.
@@ -237,7 +237,7 @@ grizzly_bear.txt:Ursus arctos horribilis
 polar_bear.txt:Ursus maritimus
 ```
 
-<div class = "learnmore">
+<div class = "learn-more">
 The [origin of "grep"](https://en.wikipedia.org/wiki/Grep) is that it is **g**lobally searching for a **r**egular **e**xpression and **p**rinting the matching lines. In the text editor `ed` that was part part of the original Unix operating system from 1969, you could do these action with the command `g/re/p` and the name has stuck.
 </div>
 

--- a/bash_conditionals_loops/bash_conditionals_loops.md
+++ b/bash_conditionals_loops/bash_conditionals_loops.md
@@ -113,7 +113,7 @@ To **iterate** an action or command is to run it again and again. A common situa
 A **loop** is a bit of code that allows you to run the same command again and again. The loop gives instructions for how many times to run your code, and if it requires input, what that input should be.  With loops, you get to write your command once and then tell it to run as many times as you want!
 
 
-<div class = "learnmore">
+<div class = "learn-more">
 
 There are two kinds of loops: "for loops" and "while loops." In this lesson we will focus on "for loops" which are generally easier to create. "While loops" can be more powerful than for loops in [certain situations](https://betterprogramming.pub/how-to-pick-between-a-while-and-for-loop-14ef217c3776), so once you understand "for loops" they are worth checking out in your preferred programming languages.
 
@@ -559,7 +559,7 @@ A lot of the statements we have used in this module use Bash's `test` utility. Y
 |`[ INTEGER1 -gt INTEGER2 ]` | INTEGER1 is greater than  INTEGER2|
 |`[ INTEGER1 -lt INTEGER2 ]` | INTEGER1 is less than INTEGER2|
 
-<div class = "learnmore">
+<div class = "learn-more">
 
 As you use them more, you will learn more and more ways to combine and mix mathematical statements to make new ones. An exclamation point `!` lets you negate a statement, and the double brackets we saw in the second example allow us to combine expressions with **and** and **or** statements.
 

--- a/data_visualization_in_ggplot2/data_visualization_in_ggplot2.md
+++ b/data_visualization_in_ggplot2/data_visualization_in_ggplot2.md
@@ -206,7 +206,7 @@ In ggplot2, you use the ggplot() function to generate an empty base plot, and th
 
 At first, this seems like more work than just using a single command in another plotting system, and it is true that ggplot visualizations are often more lines of code than other kinds of visualizations. The idea of breaking a plot into different kinds of pieces and applying each as a layer has some advantages, though, in that it makes it easier to tweak plots to get exactly what you want --- this is important both for generating plots that can be made to adhere to formatting rules (like for a journal article submission), and because tweaking a plot and re-visualizing the data is a powerful way to explore trends and patterns when you're analyzing a data set.
 
-<div class = "learnmore">
+<div class = "learn-more">
 To learn more about the theory behind ggplot2, read [Hadley Wickham's article, "A Layered Grammar of Graphics"](http://vita.had.co.nz/papers/layered-grammar.pdf)
 </div>
 
@@ -238,7 +238,7 @@ library(ggplot2)
 
 ```
 
-<div class = "learnmore">
+<div class = "learn-more">
 The readr and dplyr packages, like ggplot2, are part of the [tidyverse](https://www.tidyverse.org/), a set of R packages for data science. Check out the free R for Data Science book online to learn more about both readr (the [data import](https://r4ds.had.co.nz/data-import.html) chapter) and dplyr (the [data transformation](https://r4ds.had.co.nz/transform.html) chapter).
 </div>
 
@@ -249,7 +249,7 @@ breast_cancer_data <- read_csv("https://archive.ics.uci.edu/ml/machine-learning-
 
 ```
 
-<div class="learnmore">
+<div class="learn-more">
 Run the above code yourself in binder (see [lesson preparation](#lesson-preparation) for links to start the binder instance) or on your own computer.
 
 In the @r_code rmd file, the code at the top of the file includes these library commands and the command to read the csv file for the data. Before you will be able to generate the plots in the rest of the module, you should run those lines of code.
@@ -347,7 +347,7 @@ ggplot(breast_cancer_data, mapping = aes(y=Glucose, x=Age, color = Class_factor,
 
 Finally, we can control the background (and other aspects of the plot's general appearance) by adjusting the theme. There are quite a lot of [pre-made themes available](https://ggplot2-book.org/polishing.html#themes), or you can [specify your own](https://ggplot2-book.org/polishing.html#modifying-theme-components). I'll use the theme called theme_bw().
 
-<div class = "learnmore">
+<div class = "learn-more">
 Some journals or other organizations have pre-made ggplot2 themes available that you can apply to make your plots adhere to their aesthetic guidelines. It's worth asking! For more information about using themes and modifying them to meet journal requirements, see the [figures chaper in Writing Papers with R and Friends](https://bookdown.org/content/43652694-3819-41d2-9e70-8cfc8dd25fd1/figures.html).  
 </div>
 
@@ -610,7 +610,7 @@ Line plots are especially useful when you want to show data points that are conn
 A word of caution: You may see line plots where the data points don't actually share a meaningful theoretical connection (e.g. all being from the same patient, or the same group). Although it's not uncommon, this is generally not considered good practice and you may receive pushback from reviewers or readers.
 </div>
 
-<div class = "learnmore">
+<div class = "learn-more">
 A more detailed [tutorial on plotting time series in ggplot2](https://www.r-graph-gallery.com/279-plotting-time-series-with-ggplot2.html), including options for changing the way dates display along the x-axis.
 </div>
 
@@ -832,7 +832,7 @@ The geom\_abline() function allows you to specify a y-intercept and slope (which
 
 The first step is to run the linear model you want to get trend lines from. We won't step through how to run linear models in R here.
 
-<div class = "learnmore">
+<div class = "learn-more">
 For a more in-depth example of linear regression models in R, including using geom\_abline to draw linear trend lines, see this [Arcus Education post on ordinary linear regression](https://education.arcus.chop.edu/ordinary_linear_regression/).
 </div>
 

--- a/data_visualization_in_open_source_software/data_visualization_in_open_source_software.md
+++ b/data_visualization_in_open_source_software/data_visualization_in_open_source_software.md
@@ -182,7 +182,7 @@ There are some basic best practice guidelines you can use to make your visualiza
 - Avoid using color as the sole indicator for important information. Instead, double color up with a second indicator like shape or line type.
 - Keep visualizations clean and simple, avoiding unnecessary visual clutter. In other words, keep the [data-to-ink ratio](https://infovis-wiki.net/wiki/Data-Ink_Ratio) high.
 
-<div class="learnmore">
+<div class="learn-more">
 
 **What about colorblind-friendly palettes?**
 

--- a/data_visualization_in_seaborn/data_visualization_in_seaborn.md
+++ b/data_visualization_in_seaborn/data_visualization_in_seaborn.md
@@ -142,7 +142,7 @@ import seaborn as sns
 </div>
 
 
-<div class = "learnmore">
+<div class = "learn-more">
 The [`pandas` module](https://pandas.pydata.org/docs/getting_started/index.html)) is for working with data in python. It is conventional to import `pandas` as `pd`.
 
 The [`numpy` module](https://numpy.org/) has several useful functions for statistical calculations and other mathematical operations useful in scientific computing. It is conventional to import `numpy` as `np`.
@@ -169,7 +169,7 @@ print(covid_data.shape) # gives the number of rows and columns
 These data are from a COVID-19 serological survey conducted in Yaounde, Cameroon (Nwosu, K., Fokam, J., Wanda, F. et al., 2021[^1](Kene David Nwosu, Joseph Fokam, Franck Wanda, Lucien Mama, Erol Orel, Nicolas Ray, Jeanine Meke, Armel Tassegning, Desire Takou, Eric Mimbe, Beat Stoll, Josselin Guillebert, Eric Comte, Olivia Keiser, & Laura Ciaffi. 2021. kendavidn/yaounde\_serocovpop\_shared: Initial release v1.0.0. Zenodo. https://doi.org/10.5281/zenodo.5218965)). The authors have made all of the code and data publicly available under a [creative commons 4.0 license](https://creativecommons.org/licenses/by/4.0/legalcode) to facilitate re-use.
 
 
-<div class="learnmore">
+<div class="learn-more">
 To learn more about the study, see the [zenodo page for this dataset](https://zenodo.org/record/5218965#.YeBq2RPMITW). You can also read the published article online: [SARS-CoV-2 antibody seroprevalence and associated risk factors in an urban district in Cameroon](https://www.nature.com/articles/s41467-021-25946-0).
 </div>
 
@@ -277,7 +277,7 @@ covid_data['is_smoker'] = covid_data['is_smoker'].replace(orig_codes, new_codes)
 </div>
 
 
-<div class = "learnmore">
+<div class = "learn-more">
 For a refresher, see this tutorial on [recoding variables in a pandas dataframe](https://www.sfu.ca/~mjbrydon/tutorials/BAinPy/05_recode.html#replacing-values-from-a-list).
 </div>
 
@@ -394,7 +394,7 @@ For example, `sns.set_theme(palette="colorblind")` will set the colorblind palet
 We'll add that to the code that runs automatically at the top of each page.
 Now all of our plots will use the `colorblind` palette, unless we specify otherwise.
 
-<div class = "learnmore">
+<div class = "learn-more">
 The seaborn library has many different built-in color palettes to choose from. To learn more about setting custom colors in seaborn visualizations, see the [seaborn tutorial on color palettes](https://seaborn.pydata.org/tutorial/color_palettes.html).
 </div>
 
@@ -407,7 +407,7 @@ The seaborn library handles the appearance of plots with two kinds of functions:
 
 Seaborn controls style and context separately so that you can get a plot that has all the style elements you want, and then you can present that same plot scaled appropriately in different contexts --- for example, if you want to include it in a slide deck presentation, you probably want the fonts much larger and the lines heavier than you would if you wanted to include it as a figure in a paper. In this case, you would leave all of the style settings the same, but change context to "talk" to scale it for the slide deck and "paper" to scale it for use in the paper.
 
-<div class = "learnmore">
+<div class = "learn-more">
 We'll show a quick example of changing style and context here, but there are many more options available. To learn more about tweaking style and context, see the [seaborn tutorial on controlling figure aesthetics](https://seaborn.pydata.org/tutorial/aesthetics.html).
 </div>
 
@@ -761,7 +761,7 @@ plt.show()
 
 By default, it plots x and y as a scatterplot, adding a marginal histogram for each.
 
-<div class = "learnmore">
+<div class = "learn-more">
 Learn more about a variety of ways to add marginal distribution information to plots in the [seaborn distributions tutorial](https://seaborn.pydata.org/tutorial/distributions.html#distribution-visualization-in-other-settings).
 </div>
 
@@ -921,7 +921,7 @@ plt.show()
 
 </details>
 
-<div class = "learnmore">
+<div class = "learn-more">
 For many more examples of line plots, see the [seaborn relplot tutorial section on line plots](https://seaborn.pydata.org/tutorial/relational.html#emphasizing-continuity-with-line-plots).
 </div>
 
@@ -1173,7 +1173,7 @@ In general, polynomial models are a good choice when the polynomial relationship
 
 If you want a high level of flexibility in your trend line, you can achieve that with much less complexity by switching to a non-parametric approach like [local regression](https://en.wikipedia.org/wiki/Local_regression), one example of which is lowess ("locally weighted scatterplot smoothing") curves.
 
-<div class = "learnmore">
+<div class = "learn-more">
 For a deeper understanding of what is meant by parametric vs. non-parametric models, see section 2.1.2 of the book [Statistical Learning](https://hastie.su.domains/ISLR2/ISLRv2_website.pdf).
 
 For a good conceptual explanation of lowess curves in particular, see the [StatsQuest video "Lowess and Loess, Clearly Explained"](https://www.youtube.com/watch?v=Vf7oJ6z2LCc).
@@ -1211,7 +1211,7 @@ plt.show()
 
 </details>
 
-<div class = "learnmore">
+<div class = "learn-more">
 There are several more options for kinds of trend lines to draw in `seaborn`, including [logistic regression trend lines and robust regression trend lines](https://seaborn.pydata.org/tutorial/regression.html#fitting-different-kinds-of-models).
 </div>
 

--- a/git_creation_and_tracking/git_creation_and_tracking.md
+++ b/git_creation_and_tracking/git_creation_and_tracking.md
@@ -169,7 +169,7 @@ including all files and sub-directories located within the project's directory.
 If we ever delete the `.git` subdirectory,
 we will lose the project's history.
 
-<div class = "learnmore">
+<div class = "learn-more">
 What are the series of dots preceding `.git`?  The `.` (pronounced "dot") refers to the directory you are currently in, while `..` ("dot dot") refers to the parent of the directory you are currently in. Every directory automatically contains both `.` and `..` as things you can use as quick shorthand if you need to use them to navigate through the file structure.  What we're seeing here, then, is really a list of three things that stay hidden unless you specify that you want to see hidden things: (1)`.`, (2) `..`, and (3) `.git`
 </div>
 
@@ -199,7 +199,7 @@ nothing to commit (create/copy files and use "git add" to track)
 If you are using a different version of Git, the exact
 wording of the output might be slightly different.
 
-<div class ="learnmore">
+<div class ="learn-more">
 You will see that the primary branch of some projects, particularly older projects, is called `master` instead of `main`. GitHub has joined the programming community in a concerted effort to [replace programming terms associated with slavery](https://www.zdnet.com/article/github-to-replace-master-with-alternative-term-to-avoid-slavery-references/).
 </div>
 
@@ -725,7 +725,7 @@ results/
 
 These patterns tell Git to ignore any file whose name ends in `.dat` and everything in the `results` directory. (If any of these files were already being tracked, Git would continue to track them.)
 
-<div class = "learnmore">
+<div class = "learn-more">
 There are many common file types that people frequently ask Git not to track. For example Mac users usually want Git to ignore `.DS_store`, which is an invisible file that gets created by opening a file in Finder. You can even start with [this collection of common configurations](https://gist.github.com/octocat/9257657) for `.gitignore`.
 </div>
 
@@ -789,7 +789,7 @@ results/
 nothing to commit, working directory clean
 ```
 
-<div class = "learnmore">
+<div class = "learn-more">
 For more details on how to use `.gitignore` to include or exclude particular files or folders check out Software Carpentry's [lesson on Ignoring Things](https://swcarpentry.github.io/git-novice/06-ignore/index.html).
 </div>
 

--- a/git_history_of_project/git_history_of_project.md
+++ b/git_history_of_project/git_history_of_project.md
@@ -143,7 +143,7 @@ Using `HEAD` to refer to your commits can be great for looking at recent version
 
 ![On the left, the stack of 3 flat white boxes are labeled `HEAD`, `HEAD~1`,  and `HEAD~2`. An arrow points to a stack on the right made of the 3 white boxes with a 4th red box now on top. This red box is now the one labeled `HEAD` and the boxes below it are labeled, in order from top to bottom, `HEAD~1`, `HEAD~2`, `HEAD~3`, with all the white boxes having changed labels.](media/commit_stack_head1.svg)
 
-<div class = "learnmore">
+<div class = "learn-more">
 Git is a big pile of mixed metaphors, and in the case of `HEAD`, it is referencing the idea of a [recording head](https://en.wikipedia.org/wiki/Recording_head) which writes audio or video input to a tape.
 
 `HEAD` is a "pointer," it doesn't contain any information of its own. `HEAD` points to the commit you are currently working from, and it is possible to change which commit `HEAD` is pointing to. Moving `HEAD` so that it points somewhere else can be useful when you are trying to go back to an earlier version of your work, but is outside the scope of this module.
@@ -185,7 +185,7 @@ The first thing to notice is that your commit messages are here! This is a good 
 The second thing to notice is the structure of each entry in the log: commit, Author, Date, message.
 When you identify which commit you want to look at, the commit number is the 40 digit string of letters and numbers at the top of it after the word "commit". In Dracula's repository, the identifier for the commit in which he "add[ed] concerns about effects of Mars' moons on Wolfman" is `1e587d25f619aa0aa10fce19b44e4e71503fa41e`.
 
-<div class = "learnmore">
+<div class = "learn-more">
 **What is this number?**
 
 We are used to seeing numbers in base 10, which are made up of ten digits. Commit numbers are in base 16, called [hexadecimal](https://en.wikipedia.org/wiki/Hexadecimal). In this number system, we use the 10 familiar digits `1,2,3,4,5,6,7,8,9` as well as the digits `a,b,c,d,e,` and `f` corresponding to 10,11,12,13,14, and 15 respectively in base 10.
@@ -286,7 +286,7 @@ An ill-considered change
 
 Notice that we did NOT add or commit that last change to `mars.txt`. When you are working on a large project, it is very easy to lose track in your mind of when you last committed, or what changes you have made since. In this section we will see how to ask Git to tell us that information.
 
-<div class = "learnmore">
+<div class = "learn-more">
 You can change things in the `planets` directory that you downloaded from GitHub!
 
 Because these files now exist on your computer, you can change them and commit those changes. The author of the new commits will be you, not Vlad Dracula. You can use `git log` to see which of you made which commit.

--- a/git_intro/git_intro.md
+++ b/git_intro/git_intro.md
@@ -98,7 +98,7 @@ A version control system is a tool that keeps track of these changes for us, eff
 The complete history of commits for a particular project and their metadata make up a [repository](https://swcarpentry.github.io/git-novice/reference.html#repository). Repositories can be kept in sync across different computers, facilitating
 collaboration among different people.
 
-<div class = "learnmore">
+<div class = "learn-more">
 **The Long History of Version Control Systems**
 
 Automated version control systems are nothing new.

--- a/git_setup_mac_and_linux/git_setup_mac_and_linux.md
+++ b/git_setup_mac_and_linux/git_setup_mac_and_linux.md
@@ -129,7 +129,7 @@ Different operating systems use different character(s) to represent the end of a
 Because Git uses these characters to compare files,
 it may cause unexpected issues when editing a file on different machines.
 
-<div class = "learnmore">
+<div class = "learn-more">
 Though it is beyond the scope of this lesson, you can read more about this issue
 [in the Pro Git book](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).
 </div>
@@ -280,7 +280,7 @@ Asking a peer (in person, or via an online community of practice) is probably th
 
 <summary>**Curious about that `alias` command? Click to learn more.**</summary>
 
-<div class = "learnmore">
+<div class = "learn-more">
 This command is an example of [how to set aliases in Git](https://www.atlassian.com/git/tutorials/git-alias), something we didn't cover in this lesson.
 
 Basically, aliases are shortcuts you can write for yourself so you don't have to type out full Git commands every time. We won't be using aliases in the lessons here, but you may like to set some up on your own computer if that sounds attractive to you!

--- a/git_setup_windows/git_setup_windows.md
+++ b/git_setup_windows/git_setup_windows.md
@@ -161,7 +161,7 @@ Different operating systems use different character(s) to represent the end of a
 Because Git uses these characters to compare files,
 it may cause unexpected issues when editing a file on different machines.
 
-<div class = "learnmore">
+<div class = "learn-more">
 Though it is beyond the scope of this lesson, you can read more about this issue
 [in the Pro Git book](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).
 </div>
@@ -317,7 +317,7 @@ Asking a peer (in person, or via an online community of practice) is probably th
 
 <summary>**Curious about that `alias` command? Click to learn more.**</summary>
 
-<div class = "learnmore">
+<div class = "learn-more">
 This command is an example of [how to set aliases in Git](https://www.atlassian.com/git/tutorials/git-alias), something we didn't cover in this lesson.
 
 Basically, aliases are shortcuts you can write for yourself so you don't have to type out full Git commands every time. We won't be using aliases in the lessons here, but you may like to set some up on your own computer if that sounds attractive to you!

--- a/omics_orientation/omics_orientation.md
+++ b/omics_orientation/omics_orientation.md
@@ -54,7 +54,7 @@ script: https://kit.fontawesome.com/83b2343bd4.js
 
 "**Omics**" (pronounced OH-micks) is a suffix added to a large number of biological disciplines which denotes a "comprehensive, or global, assessment of a set of molecules" (Hasin et al., 2017) related to that domain.  Genomics is possibly the most well-known member of this family of disciplines, but is certainly not the only one! Omics has become something of a buzzword in recent years with the improvement of high-throughput technologies and increased ability to analyze large amounts of data.
 
-<div class = "learnmore">
+<div class = "learn-more">
 Much of the content of this module, particularly the definitions of specific omics domains, was derived from an article by Hasin *et al.* published in the journal *Genome Biology*. The citation is below and the article is open source if you are interesting in reading more about this topic.
 
 <div style = "margin-left: 40px; text-indent: -40px; font-size:0.8em;">

--- a/pandas_transform/pandas_transform.md
+++ b/pandas_transform/pandas_transform.md
@@ -149,7 +149,7 @@ You can navigate the pages of this course using left and right arrow keys. This 
 
 The `pandas` [package](https://pandas.pydata.org/) lets you store, examine, and manipulate tabular data using python. Since many machine learning tools use python, it can be particularly useful to process tabular data in that same environment.
 
-<div class = "learnmore">
+<div class = "learn-more">
 Most people associate "pandas" with the large mammals [Ailuropoda melanoleuca](https://en.wikipedia.org/wiki/Giant_panda). The `pandas` package is actually a shortening of "panel data."
 </div>
 
@@ -976,7 +976,7 @@ How would you **change** the the `last_name` column of `covid_testing` to be upp
 </div>
 ***
 
-<div class = "learnmore">
+<div class = "learn-more">
 
 The method `.str.lower()` will make every entry in a column lower case. There are several [other ways to manipulate the presentation of text](https://pandas.pydata.org/docs/reference/api/pandas.Series.str.lower.html) in a pandas series.
 

--- a/r_basics_transform_data/r_basics_transform_data.md
+++ b/r_basics_transform_data/r_basics_transform_data.md
@@ -568,7 +568,7 @@ Both pipe operators pass the **object on its left** as the **first argument** to
 
 In this module, **we'll use the "original" pipe (`%>%`)** in code examples and quiz questions, because we think this is the one you'll see the most in code that your coworkers share with you or you find in online examples.  This will gradually change, and as the "native" pipe (`|>`) gains market share, we'll likely change these materials to reflect that.
 
-<div class = "learnmore">
+<div class = "learn-more">
 **Optional read: Why are there two pipes?**
 
 Lots of R users got used to using the pipe after working in the `tidyverse`.  It became very popular, but it meant having to load up a package, whether that was `tidyverse` (which includes `dplyr`), or just `dplyr` (which silently depends on `magrittr`), or `magrittr`.

--- a/r_missing_values/r_missing_values.md
+++ b/r_missing_values/r_missing_values.md
@@ -182,7 +182,7 @@ Understanding the amount and type of missing data you have is crucial to conduct
 Although techniques for analyzing and correcting for different missingness patterns is outside the scope of this module,
 one of the first steps in any of those techniques is checking how much missing data you have and on which variables, which we will cover here.
 
-<div class="learnmore">
+<div class="learn-more">
 For an excellent introduction to different types of missing data, read Rubin's classic paper [Inference and Missing Data](http://math.wsu.edu/faculty/xchen/stat115/lectureNotes3/Rubin%20Inference%20and%20Missing%20Data.pdf).
 </div>
 
@@ -194,7 +194,7 @@ So how can you tell when you have missing data in R?
 Different statistical software mark missing values in different ways.
 In R, missing values are marked with `NA`, which is short for "Not Available".
 
-<div class = "learnmore">
+<div class = "learn-more">
 Technically, there are actually four different kinds of `NA`, one for each of the different data types in R. To learn more, read about [missing values in the free online book R for Data Science](https://r4ds.had.co.nz/vectors.html?q=missing#missing-values-4).
 
 For most practical purposes, you don't need to know anything about these different kinds of `NA`, though; they all just mean "missing", and you can usually use `NA` to refer to all of them.
@@ -212,7 +212,7 @@ Here's an example of what some data with missing values might look like when pri
 Note that the second and third rows have `NA` instead of numerical values for some of the measurements.
 The `NA` indicates a lack of any information for each of those cells; those values are missing.
 
-<div class = "learnmore">
+<div class = "learn-more">
 **What about `NULL`?**
 
 If you've been using R for a while, you may have seen `NULL` in some cases instead of `NA` when things are missing.
@@ -315,7 +315,7 @@ If it returns `TRUE`, then it assigns the next argument, in this case `NA`, whic
 If it returns `FALSE`, then it assigns the last argument, in this case `rating`, which will leave the value untouched.
 So for any `rating` values that equal -99, we're asking it to replace them with `NA`, otherwise leave them as they were.
 
-<div class="learnmore">
+<div class="learn-more">
 For more on `mutate` and `ifelse`, see the [R Basics: Data Transformation sections on `mutate`](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_transform_data/r_basics_transform_data.md#the-mutate%28%29-function) and [logical operators](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_transform_data/r_basics_transform_data.md#logical-operators), and the [`ifelse` section in the free online book Advanced R](https://adv-r.hadley.nz/control-flow.html#vectorised-if).
 </div>
 

--- a/statistical_tests/statistical_tests.md
+++ b/statistical_tests/statistical_tests.md
@@ -99,7 +99,7 @@ Principal Components Analysis (PCA) isn't an assessment of the strength of relat
 
 Models with continuous outcomes are the most commonly used statistical tests, and those which are most likely to be taught in an introductory stats text book. Many of them are actually not truly distinct tests but just different manifestations of one very powerful underlying model, the General Linear Model (GLM).
 
-<div class = "learnmore">
+<div class = "learn-more">
 For a deeper understanding of the GLM, it helps to use matrix algebra notation, as in this [matrix algebra explanation of regression models](https://online.stat.psu.edu/stat462/node/132/). It is definitely not necessary to understand the underlying math to effectively use GLM tests, though, so only go into that if it interests you.
 </div>
 


### PR DESCRIPTION
This is an update to the css file for all modules. It make several adjustments to highlight boxes:

- Adds new highlight boxes (e.g. `cool-fact`, `history`) 
- Replaces the icons before several kinds of highlight boxes
- Adds automatic text to the beginning of each highlight box
- Renames `learnmore` to `learn-more` for consistency with other multi-word divs
- Removes `hint` boxes, which we were not using
- Update from Font Awesome 5 to 6

In addition to the css file itself, this PR also includes changes to the module template. The section on highlight boxes was substantially updated both to add the new kinds of boxes available, as well as to clarify the purpose of existing highlight boxes:
- The instructions for when to use each kind of highlight box have been changed
- The examples for each highlight box have also been updated

NOTE: This qualifies as a major revision of the module template. Modules made with the previous template may use highlight boxes in a way that would be inconsistent with the updated template, especially ones that were particularly unclear or inconsistent in the previous template (e.g. care vs. help, warning vs. important, options vs. learnmore). 

Finally, all existing markdown files that included the string `learnmore` have had it updated to `learn-more`. Oh, and I alphabetized the list of highlight boxes, both in the module template and the css file, to make it a little easier to navigate. 