### PR TITLE
remove reminder to change REDCap link

### DIFF
--- a/omics_orientation/omics_orientation.md
+++ b/omics_orientation/omics_orientation.md
@@ -2,7 +2,7 @@
 
 author:   Meredith Lee
 email:    leemc@chop.edu
-version:  1.1.0
+version:  1.1.1
 module_template_version: 3.0.0
 language: en
 narrator: UK English Female
@@ -203,5 +203,3 @@ We ask you to fill out a brief (5 minutes or less) survey to let us know:
 * If we gave you the experience you expected
 
 We gather this information in order to iteratively improve our work.  Thank you in advance for filling out [our brief survey](https://redcap.chop.edu/surveys/?s=KHTXCXJJ93&module_name=%22Omics+Orientation%22)!
-
-Remember to change the redcap link so that the module name is correct for this module!


### PR DESCRIPTION
note reminding to update the REDCap link with the correct module name accidentally made it into the module