### PR TITLE
A11y improvements and description of learning_bash

### DIFF
--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -62,7 +62,9 @@ If you are using a computer with running iOS (i.e. a Mac) you can use the **Term
 <div class = "important">
 We want to be able to search, move, and rename files during this module, but don't want to do that with your important files. Therefore we will set up a little directory with a few files to experiment with. You can safely delete the whole thing afterwards if you want.
 
-The `learning_bash` folder contains a few different types of files for us to experiment with. The ones we will be using in this module are:
+
+The `learning_bash` folder contains a few different types of files and folders for us to experiment with. The ones we will be using in this module are:
+
 * a `.csv` file called `Animals.csv` containing a list of animals and whether they are birds, mammals, fish, reptiles, or insects.
 * `.txt` files like `black_bear.txt` containing a single line with the scientific name of an animal species.
 * `.dat` files like `blue_whale.dat` containing two lines with data about an animal's length and weight.

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -2,7 +2,7 @@
 
 author:   Elizabeth Drellich and Nicole Feldman
 email:    drelliche@chop.edu and feldmanna@chop.edu
-version: 1.0.1
+version: 1.1.0
 module_template_version: 2.0.1
 language: en
 narrator: UK English Female
@@ -61,6 +61,11 @@ If you are using a computer with running iOS (i.e. a Mac) you can use the **Term
 
 <div class = "important">
 We want to be able to search, move, and rename files during this module, but don't want to do that with your important files. Therefore we will set up a little directory with a few files to experiment with. You can safely delete the whole thing afterwards if you want.
+
+The `learning_bash` folder contains a few different types of files for us to experiment with. The ones we will be using in this module are:
+* a `.csv` file called `Animals.csv` containing a list of animals and whether they are birds, mammals, fish, reptiles, or insects.
+* `.txt` files like `black_bear.txt` containing a single line with the scientific name of an animal species.
+* `.dat` files like `blue_whale.dat` containing two lines with data about an animal's length and weight.
 </div>
 
 <div class = "warning">
@@ -73,8 +78,10 @@ Please download a fresh copy of these files. If you have downloaded them for a p
 
 Download the [`learning_bash` directory](https://github.com/arcus/learning_bash) from GitHub. Once you go to the link:
 
-1. Click on the green **Code** button.
-2. Select **Download ZIP**
+1. Click on the green **Code** button. There are two "Code" buttons! The one directly below `arcus/learning_bash` functions more like a "home" button. One line below is a dropdown menu labeled `main` and to the right of `main` are three buttons: `Go to File`, `Add File`, and `Code`. This is the **Code** button you want.
+
+2. Select **Download ZIP** from the options that appear on clicking the **Code** button.
+
 3. Once the Zip file has downloaded, un-zipping it will create a folder titled `learning_bash-main`. Depending on your computer's operating system, you may be able to un-zip the folder by double clicking on it, or may need to right click on it a select "Extract All." This may create an identically named folder inside `learning_bash-main` that contains all of the individual files.
 4. [Find out the file path](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md#6) (location on your computer) of the new folder `learning_bash-main` and navigate there in your command line interface.
 

--- a/bash_command_line_102/bash_command_line_102.md
+++ b/bash_command_line_102/bash_command_line_102.md
@@ -2,7 +2,7 @@
 
 author:   Nicole Feldman and Elizabeth Drellich
 email:    feldmanna@chop.edu and drelliche@chop.edu
-version: 1.1.1
+version: 1.2.0
 module_template_version: 2.0.0
 language: en
 narrator: UK English Female
@@ -69,9 +69,9 @@ We want to be able to search, move, and rename files during this module, but don
 
 Download the [`learning_bash` directory](https://github.com/arcus/learning_bash) from GitHub. Once you go to the link:
 
-1. Click on the green **Code** button.
+1. Click on the green **Code** button. There are two "Code" buttons! The one directly below `arcus/learning_bash` functions more like a "home" button. One line below is a dropdown menu labeled `main` and to the right of `main` are three buttons: `Go to File`, `Add File`, and `Code`. This is the **Code** button you want.
 
-2. Select **Download ZIP**
+2. Select **Download ZIP** from the options that appear on clicking the **Code** button.
 
 3. Once the Zip file has downloaded, un-zipping it will create a folder titled `learning_bash-main`. Depending on your computer's operating system, you may be able to un-zip the folder by double clicking on it, or may need to right click on it a select "Extract All." This may create an identically named folder inside `learning_bash-main` that contains all of the individual files.
 

--- a/bash_conditionals_loops/bash_conditionals_loops.md
+++ b/bash_conditionals_loops/bash_conditionals_loops.md
@@ -66,7 +66,9 @@ If you are using a computer with running iOS (i.e. a Mac) you can use the **Term
 
 We want to be able to search, move, and rename files during this module, but don't want to do that with your important files. Therefore we will set up a little directory with a few files to experiment with. You can safely delete the whole thing afterwards if you want.
 
-The `learning_bash` folder contains a few different types of files for us to experiment with. The ones we will be using in this module are:
+
+The `learning_bash` folder contains a few different types of files and folders for us to experiment with. The ones we will be using in this module are:
+
 * `.txt` files like `black_bear.txt` containing a single line with the scientific name of an animal species.
 * `.dat` files like `blue_whale.dat` containing two lines with data about an animal's length and weight.
 </div>

--- a/bash_conditionals_loops/bash_conditionals_loops.md
+++ b/bash_conditionals_loops/bash_conditionals_loops.md
@@ -2,7 +2,7 @@
 
 author:   Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.0.1
+version: 1.1.0
 module_template_version: 2.0.1
 language: en
 narrator: UK English Female
@@ -66,6 +66,9 @@ If you are using a computer with running iOS (i.e. a Mac) you can use the **Term
 
 We want to be able to search, move, and rename files during this module, but don't want to do that with your important files. Therefore we will set up a little directory with a few files to experiment with. You can safely delete the whole thing afterwards if you want.
 
+The `learning_bash` folder contains a few different types of files for us to experiment with. The ones we will be using in this module are:
+* `.txt` files like `black_bear.txt` containing a single line with the scientific name of an animal species.
+* `.dat` files like `blue_whale.dat` containing two lines with data about an animal's length and weight.
 </div>
 
 <div class = "warning">
@@ -78,8 +81,10 @@ Please download a fresh copy of these files. If you have downloaded them for a p
 
 Download the [`learning_bash` directory](https://github.com/arcus/learning_bash) from GitHub. Once you go to the link:
 
-1. Click on the green **Code** button.
-2. Select **Download ZIP**
+1. Click on the green **Code** button. There are two "Code" buttons! The one directly below `arcus/learning_bash` functions more like a "home" button. One line below is a dropdown menu labeled `main` and to the right of `main` are three buttons: `Go to File`, `Add File`, and `Code`. This is the **Code** button you want.
+
+2. Select **Download ZIP** from the options that appear on clicking the **Code** button.
+
 3. Once the Zip file has downloaded, un-zipping it will create a folder titled `learning_bash-main`. Depending on your computer's operating system, you may be able to un-zip the folder by double clicking on it, or may need to right click on it a select "Extract All." This may create an identically named folder inside `learning_bash-main` that contains all of the individual files.
 4. [Find out the file path](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md#6) (location on your computer) of the new folder `learning_bash-main` and navigate there in your command line interface.
 

--- a/bash_scripts/bash_scripts.md
+++ b/bash_scripts/bash_scripts.md
@@ -72,7 +72,9 @@ If you are using a computer running macOS (i.e. an Apple computer) you can use t
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>
 We want to be able to search, move, and rename files during this module, but don't want to do that with your important files. Therefore we will set up a little directory with a few files to experiment with. You can safely delete the whole thing afterwards if you want.
 
-The `learning_bash` folder contains a few different types of files for us to experiment with. The ones we will be using in this module are:
+
+The `learning_bash` folder contains a few different types of files and folders for us to experiment with. The ones we will be using in this module are:
+
 * a `.csv` file called `Animals.csv` containing a list of animals and whether they are birds, mammals, fish, reptiles, or insects.
 * `.dat` files like `blue_whale.dat` containing two lines with data about an animal's length and weight.
 * a folder called `scripts` containing three `.sh` files.

--- a/bash_scripts/bash_scripts.md
+++ b/bash_scripts/bash_scripts.md
@@ -2,7 +2,7 @@
 
 author:   Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.0.1
+version: 1.1.0
 module_template_version: 3.0.0
 language: en
 narrator: UK English Female
@@ -71,6 +71,17 @@ If you are using a computer running macOS (i.e. an Apple computer) you can use t
 <div class = "important">
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>
 We want to be able to search, move, and rename files during this module, but don't want to do that with your important files. Therefore we will set up a little directory with a few files to experiment with. You can safely delete the whole thing afterwards if you want.
+
+The `learning_bash` folder contains a few different types of files for us to experiment with. The ones we will be using in this module are:
+* a `.csv` file called `Animals.csv` containing a list of animals and whether they are birds, mammals, fish, reptiles, or insects.
+* `.dat` files like `blue_whale.dat` containing two lines with data about an animal's length and weight.
+* a folder called `scripts` containing three `.sh` files.
+</div>
+
+<div class = "warning">
+
+Please download a fresh copy of these files. If you have downloaded them for a previous module, you have likely moved and changed some of them while working through that module and the examples in this module assume that no changes have already been made to the directory.
+
 </div>
 
 **Download the files.**
@@ -79,8 +90,10 @@ We will be using a directory called `learning_bash` that is publicly available o
 
 Navigate in your browser to the [`learning_bash` directory](https://github.com/arcus/learning_bash) on GitHub. Once you follow the link:
 
-1. Click on the green **Code** button.
-2. Select **Download ZIP**
+1. Click on the green **Code** button. There are two "Code" buttons! The one directly below `arcus/learning_bash` functions more like a "home" button. One line below is a dropdown menu labeled `main` and to the right of `main` are three buttons: `Go to File`, `Add File`, and `Code`. This is the **Code** button you want.
+
+2. Select **Download ZIP** from the options that appear on clicking the **Code** button.
+
 3. Once the Zip file has downloaded, un-zipping it will create a folder titled `learning_bash-main`.
 4. Place this new folder `learning_bash-main` somewhere you can easily find it. In the examples we will assume that `learning_bash-main` is in the Downloads directory, but you are welcome to move it somewhere else that is convenient for you to navigate to in your command line interface.
 


### PR DESCRIPTION
This attempts to resolve 2 issues:

- providing a description of the relevant contents of the `learning_bash` folder (see issue https://github.com/arcus/education_modules/issues/228) in the 3 modules that do not walk users through exploring the folder.
- better describing the location of the "Code" button to download that folder (see issue https://github.com/arcus/education_modules/issues/222) in 4 modules that require users to download the folder.
