### PR TITLE
Remove education_module wrapper from schema, updates json stub-record; add yml stub-record

### DIFF
--- a/assets/schemas/README.md
+++ b/assets/schemas/README.md
@@ -1,0 +1,21 @@
+# On-the-fly Validation for YAML in VSCode
+
+To allow for on-the-fly validation in VSCode, you need to update the settings in your instance of VSCode or supply the correct relative path in a $schema key in the archival-request.yml file.
+
+- Install the [Red Hat YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) for VSCode.
+
+- Follow [these instructions] (https://github.com/redhat-developer/vscode-yaml#associating-a-schema-to-a-glob-pattern-via-yamlschemas) to access and update yaml settings in your instance of VSCode. A specific example of updates to the settings.json file that associates module-name.md files to their schemas may look as follows:
+`````    
+{
+    "window.zoomLevel": 1,
+    "editor.renderWhitespace": "all",
+    "editor.minimap.enabled": false,
+    "yaml.schemas": {
+        "/Users/pakstisj/Documents/GitHub/education_modules/assets/schemas/metadata_schema.json": ["stub-record.yml", "/Users/pakstisj/Documents/GitHub/education_modules/*/*.md"]
+    },
+    "yaml.customTags": [    
+    ]
+}
+`````
+- Alternatively, you could use the following relative link format in an archival-request.yml file in the `labs` repo. This assumes you have the `labs` repo and the `library` stored parallel to one another in the directory structure on your local machine. Because this method makes assumptions about the location of cloned repos, the editor yaml schema association method is preferred. 
+  - `# yaml-language-server: $schema=../../../../../../../archival_request/schema.json`

--- a/assets/schemas/metadata_schema.json
+++ b/assets/schemas/metadata_schema.json
@@ -201,11 +201,5 @@
       "type": "object"
     }
   },
-  "properties": {
-    "education_module": {
-      "$ref": "#/definitions/education_moduleDef"
-    }
-  },
-  "required": ["education_module"],
-  "type": "object"
+  "$ref": "#/definitions/education_moduleDef"
 }

--- a/assets/schemas/stub-record.json
+++ b/assets/schemas/stub-record.json
@@ -1,83 +1,80 @@
 {
-  "$schema": "./metadata_schema.json",
-  "education_module": {
-    "author": "TBD",
-    "email": "TBD", 
-    "version": "TBD",
-    "module_template_version": "TBD",
-    "language": "TBD",
-    "narrator":"TBD",
-    "title": "TBD",
-    "comment": "TBD",
-    "long_description": "TBD",
-    "estimated_time": "TBD",
-    "@learning_objectives": "TBD",
-    "@pre_reqs": "TBD",
-    "good_first_module": false,
-    "data_domain": "TBD",
-    "data_task": "data_analysis",
-    "coding": [
-      {
-      "coding_required": true,
-      "coding_level": "beginner",
-      "coding_language": [ 
-          "sql",
-          "regex"
-      ]
-      }
-    ],
-    "sequence": [
-      {
-      "sequence_name": "Git",
-      "relation_type": "sequence",
-      "next_sequential_module": "r_basics_transform_data"
-      }
-    ],
-    "relationship": [
-      {
-        "this_module": "git_intro",
-        "relation_type": "sets_you_up_for",
-        "related_module": [
-          "git_creation_and_tracking",
-          "git_setup_windows",
-          "bash_command_line_101"
-        ]
-      },
-      {
-        "this_module": "git_setup_windows",
-        "relation_type": "is_parallel_to",
-        "related_module": [
-          "git_setup_mac_and_linux"
-        ]
-      },
-      {
-        "this_module": "git_setup_windows",
-        "relation_type": "depends_on_knowledge_available_in",
-        "related_module": [
-        "git_intro"
-       ]
-      },
-      {
-      "this_module": "git_setup_windows",
-      "relation_type": "sets_you_up_for",
-      "related_module": [ 
-        "git_creation_and_tracking"
-      ]
-      },
-      {
-        "this_module": "pandas_transform",
-        "relation_type": "sets_you_up_for",
-        "related_module": [
-          "python_practice"
-        ]
-      },
-      {
-        "this_module": "python_practice",
-        "relation_type": "depends_on_knowledge_available_in",
-        "related_module": [
-          "pandas_transform"
-        ]
-      }
+  "author": "TBD",
+  "email": "TBD", 
+  "version": "TBD",
+  "module_template_version": "TBD",
+  "language": "TBD",
+  "narrator":"TBD",
+  "title": "TBD",
+  "comment": "TBD",
+  "long_description": "TBD",
+  "estimated_time": "TBD",
+  "@learning_objectives": "TBD",
+  "@pre_reqs": "TBD",
+  "good_first_module": false,
+  "data_domain": "TBD",
+  "data_task": "data_analysis",
+  "coding": [
+    {
+    "coding_required": true,
+    "coding_level": "beginner",
+    "coding_language": [ 
+        "sql",
+        "regex"
     ]
-  }  
+    }
+  ],
+  "sequence": [
+    {
+    "sequence_name": "Git",
+    "relation_type": "sequence",
+    "next_sequential_module": "r_basics_transform_data"
+    }
+  ],
+  "relationship": [
+    {
+      "this_module": "git_intro",
+      "relation_type": "sets_you_up_for",
+      "related_module": [
+        "git_creation_and_tracking",
+        "git_setup_windows",
+        "bash_command_line_101"
+      ]
+    },
+    {
+      "this_module": "git_setup_windows",
+      "relation_type": "is_parallel_to",
+      "related_module": [
+        "git_setup_mac_and_linux"
+      ]
+    },
+    {
+      "this_module": "git_setup_windows",
+      "relation_type": "depends_on_knowledge_available_in",
+      "related_module": [
+      "git_intro"
+      ]
+    },
+    {
+    "this_module": "git_setup_windows",
+    "relation_type": "sets_you_up_for",
+    "related_module": [ 
+      "git_creation_and_tracking"
+    ]
+    },
+    {
+      "this_module": "pandas_transform",
+      "relation_type": "sets_you_up_for",
+      "related_module": [
+        "python_practice"
+      ]
+    },
+    {
+      "this_module": "python_practice",
+      "relation_type": "depends_on_knowledge_available_in",
+      "related_module": [
+        "pandas_transform"
+      ]
+    }
+  ]
 }

--- a/assets/schemas/stub-record.yml
+++ b/assets/schemas/stub-record.yml
@@ -1,0 +1,42 @@
+author:   Nicole Feldman and Elizabeth Drellich
+email:    feldmanna@chop.edu drelliche@chop.edu
+version: 1.4.0
+module_template_version: 3.0.0
+language: en
+narrator: UK English Female
+title: Bash / Command Line 101
+comment:  This course teaches learners to navigate their computer, as well as view and edit files, from the command line using Bash.
+
+long_description: This course is designed to be both an introduction to bash / command line for those who are total newbies as well as refresher for those some with experience running code who want a more solid command of the basics.
+
+estimated_time: 40 minutes
+
+"@learning_objectives": "After completion of this module, learners will be able to: \n- Describe what bash scripting is and why they might want to learn it for data management and research \n- Navigate their file system using the bash shell \n- View and edit the contents of a file from the bash shell @end"
+
+"@pre_reqs": "Learners should be familiar with locating files and folders stored in a directory system.  Our [Directories and File Paths](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md#1) module can provide some help with gaining these skills.@end"
+
+good_first_module: true
+
+coding:
+- coding_required: true
+  coding_language: 
+  - bash
+  coding_level: basics
+
+sequence:
+- sequence_name: Bash Basics
+  next_sequential_module: bash_command_line_102
+  relation_type: sequence
+
+relationship:
+- this_module: bash_command_line_101
+  relation_type: sets_you_up_for
+  related_module: 
+  - bash_command_line_102
+  - bash_103_combining_commands
+  - bash_conditionals_loops
+  - bash_scripts
+- this_module: bash_command_line_101
+  relation_type: depends_on_knowledge_available_in
+  related_module: 
+  - git_setup_windows


### PR DESCRIPTION
The `stub-record.yml` file just pulls the yml front matter from `bash_command_line_101.md`. `stub-record.yml` is now valid yml. 

This involved encapsulating the @ beginning keys with double quotes as well as those multi-line values. It also shoves `@end` into the double quote values. This is still not ideal but I wanted to push this into the example to serve as a start to work with. Getting closer! 