### PR TITLE
Add level 1 header to SQL table macro files

### DIFF
--- a/_module_templates/macros_sql_table_allergies.md
+++ b/_module_templates/macros_sql_table_allergies.md
@@ -174,4 +174,6 @@ comment:  This is alaSQL code to generate the allergies table.
 
 -->
 
+# Table allergies
+
 Must also import sql macros.

--- a/_module_templates/macros_sql_table_observations.md
+++ b/_module_templates/macros_sql_table_observations.md
@@ -62,4 +62,6 @@ comment:  This is alaSQL code to generate the observations table.
 
 -->
 
+# Table observations
+
 Must also import sql macros.

--- a/_module_templates/macros_sql_table_patients.md
+++ b/_module_templates/macros_sql_table_patients.md
@@ -42,4 +42,6 @@ alasql("INSERT INTO patients VALUES ('fcc61454-1b07-4e49-a25b-29e5064e0063', '19
 
 -->
 
+# Table patients
+
 Must also import sql macros.


### PR DESCRIPTION
Apparently liascript can't load a macro course via `import` unless it has a level 1 header after the front matter. Lesson learned!