### PR TITLE
Joy versioning info

### DIFF
--- a/_module_templates/macros.md
+++ b/_module_templates/macros.md
@@ -2,11 +2,19 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  1.0.0
+version:  1.1.0
+current_version_description: Add current_version_description and version_history metadata
 language: en
 narrator: UK English Female
 title: Module Macros
 comment:  This is placeholder module to save macros used in other modules.
+
+@version_history 
+
+Previous versions: 
+
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/e983922162e6fbf971c03dc96052f68713cc72af/_module_templates/macros.md#1): Initial version
+@end
 
 @overview
 <div class = "overview">
@@ -25,6 +33,12 @@ comment:  This is placeholder module to save macros used in other modules.
 **Learning Objectives**
 
 @learning_objectives
+
+**Version History**
+
+This version (@version): @current_version_description
+
+@version_history
 
 </div>
 @end

--- a/_module_templates/macros_python.md
+++ b/_module_templates/macros_python.md
@@ -2,11 +2,19 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  1.0.0
+version:  1.1.0
+current_version_description: Add current_version_description and version_history metadata
 language: en
 narrator: UK English Female
 title: Python Module Macros
 comment:  This is placeholder module to save macros used in other modules.
+
+@version_history 
+
+Previous versions: 
+
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/e983922162e6fbf971c03dc96052f68713cc72af/_module_templates/macros_python.md#1): Initial version
+@end
 
 @lesson_prep_python_sage
 @sage

--- a/_module_templates/macros_r.md
+++ b/_module_templates/macros_r.md
@@ -2,11 +2,19 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  1.0.0
+version:  1.1.0
+current_version_description: Add current_version_description and version_history metadata
 language: en
 narrator: UK English Female
 title: R Module Macros
 comment:  This is placeholder module to save macros used in other modules.
+
+@version_history 
+
+Previous versions: 
+
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/e983922162e6fbf971c03dc96052f68713cc72af/_module_templates/macros_r.md#1): Initial version
+@end
 
 @lesson_prep_r
 

--- a/_module_templates/macros_sql.md
+++ b/_module_templates/macros_sql.md
@@ -2,11 +2,19 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  1.0.0
+version:  1.1.0
+current_version_description: Add current_version_description and version_history metadata, remove @overview
 language: en
 narrator: UK English Female
 title: Module Macros for SQL
 comment:  This is placeholder module to save macros used in other modules.
+
+@version_history 
+
+Previous versions: 
+
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/e983922162e6fbf971c03dc96052f68713cc72af/_module_templates/macros_sql.md#1): Initial version
+@end
 
 @lesson_prep_sql
 
@@ -166,8 +174,6 @@ try {
 -->
 
 # Module Macros
-
-@overview
 
 ## Lesson Preparation: SQL
 

--- a/_module_templates/macros_sql_table_allergies.md
+++ b/_module_templates/macros_sql_table_allergies.md
@@ -3,10 +3,14 @@
 author:   DART Team
 email:    dart@chop.edu
 version:  1.0.0
+current_version_description: Initial version
 language: en
 narrator: UK English Female
 title: SQL allergies table
 comment:  This is alaSQL code to generate the allergies table.
+
+@version_history 
+@end
 
 @AlaSQL.buildTable_allergies
 <script>
@@ -170,8 +174,11 @@ comment:  This is alaSQL code to generate the allergies table.
     alasql("INSERT INTO allergies VALUES ('2000-01-03',null,'e6ff4bf9-09c2-4976-aa84-cca142207cf8','6c760807-a6b7-4af4-8d50-f32325803448','Allergy to eggs');");
     alasql("INSERT INTO allergies VALUES ('2000-01-03',null,'e6ff4bf9-09c2-4976-aa84-cca142207cf8','6c760807-a6b7-4af4-8d50-f32325803448','Allergy to peanuts');");
 </script>
+
 @end
 
 -->
+
+# Table allergies
 
 Must also import sql macros.

--- a/_module_templates/macros_sql_table_observations.md
+++ b/_module_templates/macros_sql_table_observations.md
@@ -3,10 +3,14 @@
 author:   DART Team
 email:    dart@chop.edu
 version:  1.0.0
+current_version_description: Initial version
 language: en
 narrator: UK English Female
 title: SQL observations table
 comment:  This is alaSQL code to generate the observations table.
+
+@version_history 
+@end
 
 @AlaSQL.buildTable_observations
 <script>
@@ -61,5 +65,7 @@ comment:  This is alaSQL code to generate the observations table.
 @end
 
 -->
+
+# Table observations
 
 Must also import sql macros.

--- a/_module_templates/macros_sql_table_patients.md
+++ b/_module_templates/macros_sql_table_patients.md
@@ -3,10 +3,14 @@
 author:   DART Team
 email:    dart@chop.edu
 version:  1.0.0
+current_version_description: Initial version
 language: en
 narrator: UK English Female
 title: SQL patients table
 comment:  This is alaSQL code to generate the patients table.
+
+@version_history 
+@end
 
 @AlaSQL.buildTable_patients
 <script>
@@ -41,5 +45,7 @@ alasql("INSERT INTO patients VALUES ('fcc61454-1b07-4e49-a25b-29e5064e0063', '19
 @end
 
 -->
+
+# Table patients
 
 Must also import sql macros.

--- a/_module_templates/macros_wrapper.md
+++ b/_module_templates/macros_wrapper.md
@@ -2,11 +2,15 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  0.0.0
+version:  1.0.0
+current_version_description: Add current_version_description and version_history metadata
 language: en
 narrator: UK English Female
 title: Wrapper Module Macros
 comment:  This is placeholder module to save macros used in other modules.
+
+@version_history  
+@end
 
 @module_structure
 1. Part 1

--- a/_module_templates/template_exercise.md
+++ b/_module_templates/template_exercise.md
@@ -3,8 +3,9 @@
 author:   Your Name
 email:    email@chop.edu
 version:  0.0.0
+current_version_description: Brief description of why this version exists
 module_type: exercise
-docs_version: 1.0.0
+docs_version: 1.1.0
 language: en
 narrator: UK English Female
 mode: Textbook
@@ -28,6 +29,15 @@ After completion of this module, learners will be able to:
 - create a product
 - do a task
 - articulate the rationale for something
+@end
+
+@version_history 
+
+Previous versions: 
+
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md

--- a/_module_templates/template_standard.md
+++ b/_module_templates/template_standard.md
@@ -3,8 +3,9 @@
 author:   Your Name
 email:    email@chop.edu
 version:  0.0.0
+current_version_description: Brief description of why this version exists
 module_type: standard
-docs_version: 1.0.0
+docs_version: 1.1.0
 language: en
 narrator: UK English Female
 mode: Textbook
@@ -28,6 +29,15 @@ After completion of this module, learners will be able to:
 - create a product
 - do a task
 - articulate the rationale for something
+@end
+
+@version_history 
+
+Previous versions: 
+
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md

--- a/_module_templates/template_wrapper.md
+++ b/_module_templates/template_wrapper.md
@@ -57,8 +57,8 @@ resource1_a11y_issues:
 3. Part 3
 @end
 
-import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
-import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_wrapper.md
+import: https://raw.githubusercontent.com/arcus/education_modules/joy-versioning-info/_module_templates/macros.md
+import: https://raw.githubusercontent.com/arcus/education_modules/joy-versioning-info/_module_templates/macros_wrapper.md
 -->
 
 # Module Title

--- a/_module_templates/template_wrapper.md
+++ b/_module_templates/template_wrapper.md
@@ -57,8 +57,8 @@ resource1_a11y_issues:
 3. Part 3
 @end
 
-import: https://raw.githubusercontent.com/arcus/education_modules/joy-versioning-info/_module_templates/macros.md
-import: https://raw.githubusercontent.com/arcus/education_modules/joy-versioning-info/_module_templates/macros_wrapper.md
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_wrapper.md
 -->
 
 # Module Title

--- a/_module_templates/template_wrapper.md
+++ b/_module_templates/template_wrapper.md
@@ -3,8 +3,9 @@
 author:   Your Name
 email:    email@chop.edu
 version:  0.0.0
+current_version_description: Brief description of why this version exists
 module_type: wrapper
-docs_version: 1.0.0
+docs_version: 1.1.0
 language: en
 narrator: UK English Female
 mode: Textbook
@@ -28,6 +29,15 @@ After completion of this module, learners will be able to:
 - create a product
 - do a task
 - articulate the rationale for something
+@end
+
+@version_history 
+
+Previous versions: 
+
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
 @end
 
 resource1_name: 


### PR DESCRIPTION
Hi @rosemm I tested that the versioning info appears as intended by switching branches in macros.md and then changing it back.  Still, I think it needs to go in all of a piece before we can really test it.  

Details: 

* The SQL table macros are fixed with a L1 header and NOT upversioned to 1.1.0, I left those as 1.0.0 so that the initial version is one that will render in Liascript
* Otherwise, the macros and templates are all upversioned
* Templates have a sample version info section
* Macros have a real version info section

Can you look over and approve when you see fit?  
