### PR TITLE
Remove text with survey link that's not rendering properly

### DIFF
--- a/_module_templates/macros_wrapper.md
+++ b/_module_templates/macros_wrapper.md
@@ -39,8 +39,6 @@ comment:  This is placeholder module to save macros used in other modules.
   list.appendChild(fragList);
 </script>
 <b>Known issues with accessibility and/or inclusion:</b> @8
-
-We do our best to list potential problems here, but we might have missed something! If you encounter an issue, please let us know in @make_survey_url(\'@title\', \'@version\', \'@module_type\').
 @end
 
 print_resource1: @print_list(@resource1_name,@resource1_description,@resource1_wellvetted,@resource1_wellvetted_text,@resource1_maintained,@resource1_maintained_text,@resource1_stablesupport,@resource1_stablesupport_text,@resource1_a11y_issues,@uid)


### PR DESCRIPTION
Little fix in the print_list macro for wrapper modules. There was a little extra line of text to add our survey link, but it's not rendering properly and the survey link is available in the feedback section anyway, of course. So just taking that out. 