### PR TITLE
Update macro info

### DIFF
--- a/_module_templates/macros_r.md
+++ b/_module_templates/macros_r.md
@@ -27,29 +27,9 @@ Please read over all the options before you start performing any actions, to mak
 
 </div>
 
-### Option 1: Work Anonymously in the Cloud
+### Option 1: Use Posit Cloud
 
-This might work well for you if you either can't or don't want to install R and RStudio on your computer.  The benefit is that you don't have to install anything or have any account set up with an online cloud provider.  This solution is completely anonymous.  However, there are some drawbacks.  One negative is that this option requires a bit of waiting for your environment to come online.  Another is that your changes aren't saved anywhere, and your environment will time out and disappear forever.  
-
-**First**, we need to create a small container in the cloud for you to work in just using your web browser.  **Click "Launch binder" below.**  It might take a while (5 minutes) to create, depending on how recently it was created (when it's being used more, it's quicker!).  We're looking for a faster way to get you off and running in RStudio without downloads and without creating accounts, but for now this is a great, free way for us to get you working with no extra work on your part.
-
-  <a href = "https://mybinder.org/v2/gh/arcus/education_r_environment/main?urlpath=rstudio" target = "_blank"><img src="https://mybinder.org/static/images/badge_logo.svg"></a> **← Click the "launch binder" button!**
-
-<div class = "important" style = "align-items: center; display: flex;">
-<b style="color: rgb(var(--color-highlight));">Important note</b><br>
-
-<div style = "margin: 1rem; max-width: 45%; float:left;"> If you're the first person to fire up this environment in a while, you might see this loading screen for up to five minutes.  Be patient!</div>
-<div style = "margin: 1rem auto; max-width: 45%; float:left;"> ![Binder loading screen.](https://github.com/arcus/education_r_environment/blob/main/media/binder_loading.gif?raw=true)
-</div>
-</div>
-
-**Then**, once you have access to RStudio and you see something like the image below, you'll need to open the sample data for this course.  In the file area to the lower right, you'll see, among multiple choices, the folder called "@r_file".  That's the code for this module!
-
-<img src="https://github.com/arcus/education_r_environment/blob/main/media/binder_rstudio.png?raw=true" alt="RStudio as shown in the cloud platform Binder." style = "border: 1px solid rgb(var(--color-highlight)); max-width: 800px;">
-
-### Option 2: Use Posit Cloud
-
-Posit (the company formerly known as RStudio) provides a multi-tiered cloud environment for using RStudio.  Unlike option 1 above, this option does require you to have an account with Posit Cloud, their online RStudio server.  The good news is that the base level of Posit Cloud is free!
+Posit (the company formerly known as RStudio) provides a multi-tiered cloud environment for using RStudio.  This option requires you to have an account with Posit Cloud, their online RStudio server.  The good news is that the base level of Posit Cloud is free!
 
 First, you'll need to [create a (free!) Posit cloud account](https://posit.cloud/plans).  
 
@@ -63,7 +43,7 @@ Click on "Save a Permanent Copy" if you want to save any changes to your version
 
 Now you can not only work in the cloud, but also save your work.
 
-### Option 3: Work on Your Computer
+### Option 2: Work on Your Computer
 
 If you have [R](https://www.r-project.org/) and [RStudio](https://www.rstudio.com/products/rstudio/download/#download) installed already on your local computer, you might be interested in simply downloading our sample code to your computer. Here's how.  Note: If you've already done this step in another module, you might have the material for this module already!
 

--- a/docs.md
+++ b/docs.md
@@ -391,9 +391,9 @@ This is rough guess of how long it might take a learner to work through the modu
 r_file: r\_logistic\_regression
 ```
 
-If this module uses binder to host an interactive rmd file, include the bare name of that file here, for example: `this\_r\_module` 
+If this module uses refers to a specific directory and file within the `education_r_environment` directory structure, you can include that directory / file name, without file extension, here, for example: `this\_r\_module`.
 
-Note that rmds in the education_r_environment repo should be saved in a directory that matches the file name, like `this_r_module/this_r_module.rmd`. When you use the [r\_lesson\_prep macro](#interactive-r), it will fill in the text from `r_file` to use as both the directory name and file name for this lesson's notebook. Use backslashes to escape underscores (e.g. `this\_r\_module` rather than `this_r_module`). 
+Note that rmds in the `education_r_environment` repo should be saved in a directory that matches the file name, like `this_r_module/this_r_module.rmd`. When you use the [r\_lesson\_prep macro](#interactive-r), it will fill in the text from `r_file` to use as both the directory name and file name for this lesson's notebook. Use backslashes to escape underscores (e.g. `this\_r\_module` rather than `this_r_module`). 
 
 ### `pre_reqs` 
 
@@ -850,7 +850,7 @@ The table of contents automatically generated from the headers should give learn
 This section will appear in any module that requires the learner to prepare in some way. For example:
 - the learner needs to download software (like git or bash)
 - the learner needs an account with an external resource (like Google Colab or AWS)
-- the learner will need to interact with an external resource (like a binderhub environment) 
+- the learner will need to interact with an external resource (like a Posit.cloud environment) 
 - the function of the module requires explanation, such as how sagemath cells work 
 
 ### Additional Resources


### PR DESCRIPTION
Changes: 

* in [_module_templates/macros_r.md](https://github.com/arcus/education_modules/compare/joy-update-binder-info?expand=1#diff-ac0523e970c8a4e47e529b715ce92d1e891e7be0ae79607d5ac7c2618a237493) I: 
  * remove option 1, binderhub, 
  * slightly reword the start of option 2, Posit.cloud, and renumber it to option 1, and
  * renumber option 3 (work in your own computer) to option 2.
* in [docs.md](https://github.com/arcus/education_modules/compare/joy-update-binder-info?expand=1#diff-6a042219e4779f0e778edb839c177737f9d49be99d5032a644a5ae7cded83876) I remove references to "binder" and refer instead to Posit.cloud or generically to the `education_r_environment` directory structure.  Please read the changes to see if they make sense to you!