### PR TITLE
Git history patch

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -712,6 +712,7 @@ Must be one of the following:
 - `sql`
 - `python_basics`
 - `genomics_tools_and_methods`
+- `git_basics`
 - (add more here)
 
 ### `previous_sequential_module`

--- a/docs.md
+++ b/docs.md
@@ -2,8 +2,8 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  1.2.0
-current_version_description: Add genomics macros
+version:  1.2.1
+current_version_description: Add genomics macros, add git_basics to the list of sequences.
 language: en
 narrator: UK English Female
 title: DART LiaScript docs

--- a/git_history_of_project/git_history_of_project.md
+++ b/git_history_of_project/git_history_of_project.md
@@ -264,6 +264,8 @@ Unlike `HEAD`, the commit number doesn't change or move as you update your repos
 
 ### Quiz: finding a commit
 
+<div>
+
 The output from `git log -n 2` is:
 
 ```
@@ -282,6 +284,8 @@ Date:   Wed Apr 6 13:15:24 2022 -0400
 ```
 
 Which of the following commands would show you the **most recent** commit you made? Select all correct answers.
+
+</div>
 
 - [[X]] `git show HEAD`
 - [[ ]] `git show HEAD~1`

--- a/git_history_of_project/git_history_of_project.md
+++ b/git_history_of_project/git_history_of_project.md
@@ -2,15 +2,30 @@
 
 author:  Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.0.3
-module_template_version: 3.0.0
+version: 1.1.0
+current_version_description: Correcting typos in quiz question answer.
+module_type: standard
+docs_version: 1.2.0
 language: en
 narrator: UK English Female
+mode: Textbook
+
 title: Exploring the History of your Git Repository
+
 comment:  This module will teach you how to look at past versions of your work on Git and compare your project with previous versions.
+
 long_description: You know that version control is important. You know how to save your work to your Git repository. Now you are ready to look at and compare different versions of your work. In this module you will you will learn how to navigate through the commits you have made to Git. You will also learn how to compare current code with past code.
 
-estimated_time: 30 minutes
+estimated_time_in_minutes: 30
+
+@pre_reqs
+To best learn from this module make sure that you:
+
+- have Git configured on your computer,
+- can view and edit `.txt` files, and
+- can make changes to a Git repository using `add` and `commit` from a command line interface (CLI).
+
+@end
 
 @learning_objectives  
 After completion of this module, learners will be able to:
@@ -21,39 +36,36 @@ After completion of this module, learners will be able to:
 
 @end
 
-link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
+good_first_module: false
+coding_required: true
+coding_level: basic
+coding_language: git, bash
+sequence_name: git_basics
+previous_sequential_module: git_creation_and_tracking
 
-script: https://kit.fontawesome.com/83b2343bd4.js
+@sets_you_up_for
 
+@end
+
+@depends_on_knowledge_available_in
+- git_intro
+- git_setup_windows
+- git_setup_mac_and_linux
+- bash_command_line_101
+- git_creation_and_tracking
+@end
+
+@version_history
+Previous versions: 
+
+- [1.0.3](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/a4ea7a7f1f9264dabe952b68941fc9f0f656c9fc/git_history_of_project/git_history_of_project.md#1): Initial version.
+@end
+
+import: 
 -->
 
 # Exploring the History of a Git Repository
-
-
-<div class = "overview">
-
-## Overview
-@comment
-
-**Is this module right for me?** @long_description
-
-**Estimated time to completion:**
-@estimated_time
-
-**Pre-requisites**
-
-To best learn from this module make sure that you:
-
-* have Git configured on your computer,
-* can view and edit `.txt` files, and
-* can make changes to a Git repository using `add` and `commit` from a command line interface (CLI).
-
-
-**Learning Objectives**
-
-@learning_objectives
-
-</div>
+@overview
 
 ## Lesson Preparation
 
@@ -531,17 +543,4 @@ and explore how it was created! One repository with particularly good documentat
 </div>
 
 ## Feedback
-
-In the beginning, we stated some goals.
-
-**Learning Objectives:**
-
-@learning_objectives
-
-We ask you to fill out a brief (5 minutes or less) survey to let us know:
-
-* If we achieved the learning objectives
-* If the module difficulty was appropriate
-* If we gave you the experience you expected
-
-We gather this information in order to iteratively improve our work.  Thank you in advance for filling out [our brief survey](https://redcap.chop.edu/surveys/?s=KHTXCXJJ93&module_name=%22Exploring+the+History+of+your+Git+Repository%22&version=1.0.3)!
+@feedback

--- a/git_history_of_project/git_history_of_project.md
+++ b/git_history_of_project/git_history_of_project.md
@@ -534,7 +534,7 @@ You can conclude from this output that you must have committed, and then added t
 
 This module was based on examples from [Software Carpentry](https://software-carpentry.org)'s [lessons on using Git](https://swcarpentry.github.io/git-novice/). The story of Dracula and Wolfman's planned trip to Mars is borrowed from them, and more examples are available in the original lesson:
 
- - Lesson 5: [Exploring History](https://swcarpentry.github.io/git-novice/05-history/index.html)
+ - Lesson 5: [Exploring History](https://swcarpentry.github.io/git-novice/05-history.html)
 
 <div class = "options">
 <b style="color: rgb(var(--color-highlight));">Another option</b><br>

--- a/git_history_of_project/git_history_of_project.md
+++ b/git_history_of_project/git_history_of_project.md
@@ -67,6 +67,15 @@ import:
 # Exploring the History of a Git Repository
 @overview
 
+<div class = "gratitude">
+<b style="color: rgb(var(--color-highlight));">Thank you!</b><br>
+
+Material for this module was adapted from [Software Carpentry's git exploring history lesson](https://swcarpentry.github.io/git-novice/05-history.html), generously published under a [CC-BY 4.0](https://swcarpentry.github.io/git-novice/LICENSE.html) license. 
+The content has been lightly edited, as well as the formatting and presentation style. 
+We are tremendously grateful to [The Carpentries](https://carpentries.org/) for creating, maintaining, and sharing this valuable resource.
+
+</div>
+
 ## Lesson Preparation
 
 The purpose of this module is to learn how to explore the history of a Git repository that has already been created. We are going to download Dracula's repository in which he started documenting the pros and cons of moving with his friends to Mars.

--- a/git_history_of_project/git_history_of_project.md
+++ b/git_history_of_project/git_history_of_project.md
@@ -294,9 +294,9 @@ Which of the following commands would show you the **most recent** commit you ma
 ***
 <div class ="answer">
 
-As long as you didn't do anything fancy to move `HEAD`, the **most recent** commit is the current `HEAD`. Its commit number is `584977`. Since both refer to the same commit, you can use either.
+As long as you didn't do anything fancy to move `HEAD`, the **most recent** commit is the current `HEAD`. Its commit number is `024af1`. Since both refer to the same commit, you can use either.
 
-The command `git show HEAD~1` will show you one checkpoint earlier in your work, while `git show 081cd9` will give you an error since `081cd9` it is not the **first** six digits of a known commit number.
+The command `git show HEAD~1` will show you one checkpoint earlier in your work, while `git show 2a29ed` will give you an error since `2a29ed` it is not the **first** six digits of a known commit number.
 
 </div>
 ***

--- a/git_history_of_project/git_history_of_project.md
+++ b/git_history_of_project/git_history_of_project.md
@@ -61,7 +61,7 @@ Previous versions:
 - [1.0.3](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/a4ea7a7f1f9264dabe952b68941fc9f0f656c9fc/git_history_of_project/git_history_of_project.md#1): Initial version.
 @end
 
-import: 
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 -->
 
 # Exploring the History of a Git Repository


### PR DESCRIPTION
Fixes #393 
Also brings front matter up to date, replaces overview and feedback text with macros, and puts a gratitude box at the end of overview to be consistent with R basics series. 
Adds `git_basics` as an official sequence in docs.md