### PR TITLE
fix make_survey_URL macro

### DIFF
--- a/_module_templates/macros.md
+++ b/_module_templates/macros.md
@@ -13,7 +13,9 @@ comment:  This is placeholder module to save macros used in other modules.
 
 Previous versions: 
 
-- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/e983922162e6fbf971c03dc96052f68713cc72af/_module_templates/macros.md#1): Initial version
+- [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/ad25398d0eef884402cff0f0c4fb4ca360d3b8f4/_module_templates/macros.md#1): Add current_version_description and version_history metadata.
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/e983922162e6fbf971c03dc96052f68713cc72af/_module_templates/macros.md#1): Initial version 
+
 @end
 
 @overview

--- a/_module_templates/macros.md
+++ b/_module_templates/macros.md
@@ -2,8 +2,8 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  1.1.0
-current_version_description: Add current_version_description and version_history metadata
+version:  2.1.0
+current_version_description: fix version piping into REDCap URL
 language: en
 narrator: UK English Female
 title: Module Macros
@@ -45,11 +45,11 @@ This version (@version): @current_version_description
 
 @make_survey_url
 <script modify="false">
-function makeURL(title, version_number, module_type) {
+function makeURL(title, version, module_type) {
   let url = new URL('https://redcap.chop.edu/surveys');
   url.searchParams.set('s', 'KHTXCXJJ93');
   url.searchParams.set('module_name', title);
-  url.searchParams.set('version_number', version_number);
+  url.searchParams.set('version', version);
   url.searchParams.set('module_type', module_type);
   return url;
 }

--- a/_module_templates/macros.md
+++ b/_module_templates/macros.md
@@ -2,7 +2,7 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  2.1.0
+version:  1.2.0
 current_version_description: fix version piping into REDCap URL
 language: en
 narrator: UK English Female


### PR DESCRIPTION
make_survey_URL was assigning the version to fill a REDCap field that didn't exist, `version_number`. Updated to correctly set it to `version` which is the name of the field in REDCap.


this (hopefully) resolves #477 