### PR TITLE
Add missing front matter fields to templates

### DIFF
--- a/_module_templates/template_exercise.md
+++ b/_module_templates/template_exercise.md
@@ -32,6 +32,9 @@ After completion of this module, learners will be able to:
 @end
 
 good_first_module: false
+coding_required: true
+coding_level: 
+coding_language: 
 
 @sets_you_up_for
 

--- a/_module_templates/template_exercise.md
+++ b/_module_templates/template_exercise.md
@@ -31,7 +31,7 @@ After completion of this module, learners will be able to:
 - articulate the rationale for something
 @end
 
-good_first_module: false
+good_first_module: 
 coding_required: true
 coding_level: 
 coding_language: 

--- a/_module_templates/template_exercise.md
+++ b/_module_templates/template_exercise.md
@@ -31,6 +31,16 @@ After completion of this module, learners will be able to:
 - articulate the rationale for something
 @end
 
+good_first_module: false
+
+@sets_you_up_for
+
+@end
+
+@depends_on_knowledge_available_in
+
+@end
+
 @version_history 
 
 Previous versions: 

--- a/_module_templates/template_standard.md
+++ b/_module_templates/template_standard.md
@@ -31,7 +31,7 @@ After completion of this module, learners will be able to:
 - articulate the rationale for something
 @end
 
-good_first_module: false
+good_first_module: 
 
 @sets_you_up_for
 

--- a/_module_templates/template_standard.md
+++ b/_module_templates/template_standard.md
@@ -31,6 +31,16 @@ After completion of this module, learners will be able to:
 - articulate the rationale for something
 @end
 
+good_first_module: false
+
+@sets_you_up_for
+
+@end
+
+@depends_on_knowledge_available_in
+
+@end
+
 @version_history 
 
 Previous versions: 

--- a/_module_templates/template_wrapper.md
+++ b/_module_templates/template_wrapper.md
@@ -31,7 +31,7 @@ After completion of this module, learners will be able to:
 - articulate the rationale for something
 @end
 
-good_first_module: false
+good_first_module: 
 
 @sets_you_up_for
 

--- a/_module_templates/template_wrapper.md
+++ b/_module_templates/template_wrapper.md
@@ -31,6 +31,16 @@ After completion of this module, learners will be able to:
 - articulate the rationale for something
 @end
 
+good_first_module: false
+
+@sets_you_up_for
+
+@end
+
+@depends_on_knowledge_available_in
+
+@end
+
 @version_history 
 
 Previous versions: 


### PR DESCRIPTION
Fixes #517 

Note: We're not incrementing versions for templates, since those version fields are intended to be filled in for whatever module the author is using the template for. We might want to add a way to version templates, but for now they stay at 0.0.0