### PR TITLE
537 docs v1 update bash combine commands

### DIFF
--- a/_module_templates/macros_bash.md
+++ b/_module_templates/macros_bash.md
@@ -21,7 +21,7 @@ No Previous Versions
 You will get the most out of this lesson if you follow along with the examples and try out the commands. In order to do that you need to have a bash shell open on your computer. Please follow the instructions appropriate for the computer you are using.
 
 **Open a bash shell.**
-If you are using a computer with running iOS (i.e. a Mac) you can use the **Terminal** program. If you are on a computer using Windows, open either **WLS** (Windows Linux Subsytem) or **Git Bash**. If you don't have these programs there are instructions for how to download and set them up in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md) module.
+If you are using a computer with running a Unix operating system (i.e. a Mac or Linux computer) you can use the **Terminal** program. If you are on a computer using Windows, open either **WLS** (Windows Linux Subsytem) or **Git Bash**. If you don't have these programs there are instructions for how to download and set them up in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md) module.
 
 <div class = "care">
 <b style="color: rgb(var(--color-highlight));">A little encouragement...</b><br>

--- a/_module_templates/macros_bash.md
+++ b/_module_templates/macros_bash.md
@@ -1,0 +1,80 @@
+<!--
+
+author:   DART Team
+email:    dart@chop.edu
+version:  1.0.0
+current_version_description: Initial Version
+language: en
+narrator: UK English Female
+title: Bash Module Macros
+comment:  This is placeholder module to save macros used in other modules.
+
+@version_history 
+
+Previous versions: 
+
+No Previous Versions
+@end
+
+@lesson_prep_bash
+
+You will get the most out of this lesson if you follow along with the examples and try out the commands. In order to do that you need to have a bash shell open on your computer. Please follow the instructions appropriate for the computer you are using.
+
+**Open a bash shell.**
+If you are using a computer with running iOS (i.e. a Mac) you can use the **Terminal** program. If you are on a computer using Windows, open either **WLS** (Windows Linux Subsytem) or **Git Bash**. If you don't have these programs there are instructions for how to download and set them up in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md) module.
+
+<div class = "care">
+<b style="color: rgb(var(--color-highlight));">A little encouragement...</b><br>
+
+It can be stressful to interact with files directly from the command line. Throughout this module we will make sure you know what each command does before asking you to do it.  Like any other computational skill, you'll get more comfortable with it the more you practice!
+
+</div>
+
+To ensure that we aren't touching any of the important files on your computer, you will be downloading a small directory to experiment with.  You can download a fresh copy to start over at any point. 
+
+<div class = "warning">
+<b style="color: rgb(var(--color-highlight));">Warning!</b><br>
+
+Please download a fresh copy of these files. If you have downloaded them for a previous module, you have likely moved and changed some of them while working through that module and the examples in this module assume that no changes have already been made to the directory.
+
+</div>
+
+**Download the files.**
+
+Download the [`learning_bash` directory](https://github.com/arcus/learning_bash) from GitHub. Once you go to the link:
+
+1. Click on the green **Code** drop-down button towards the right-hand side of the screen. 
+
+2. Select **Download ZIP** from the options that appear.
+
+3. Once the Zip file has downloaded, un-zipping it will create a folder titled `learning_bash-main`. Depending on your computer's operating system, you may be able to un-zip the folder by double clicking on it, or may need to right click on it a select "Extract All." This may create an identically named folder inside `learning_bash-main` that contains all of the individual files.
+4. [Find out the file path](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md#6) (location on your computer) of the new folder `learning_bash-main` and navigate there in your command line interface.
+
+<div class = "help">
+<b style="color: rgb(var(--color-highlight));">Troubleshooting help</b><br>
+
+**Where is my folder?**
+
+If you can see the icon for your `learning_bash-main` folder (maybe in a downloads screen) you can open your command line interface directly into the folder by right clicking on the folder and selecting the appropriate option:
+
+| Command Line Interface | Right-click menu option |
+| :- | :- |
+| Terminal (Mac or Linux) | New Terminal at Folder |
+| Git Bash (Windows) | Git Bash Here |
+| WLS (Windows Linux Subsystem) | Open Linux shell here |
+
+This will open a command line interface at the correct location. Once there, you can use the command `pwd` to see the path to your present working directory.
+
+</div>
+
+@end
+
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
+-->
+
+# Bash Module Macros
+
+@lesson_prep_bash
+
+
+

--- a/_module_templates/macros_bash.md
+++ b/_module_templates/macros_bash.md
@@ -21,7 +21,7 @@ No Previous Versions
 You will get the most out of this lesson if you follow along with the examples and try out the commands. In order to do that you need to have a bash shell open on your computer. Please follow the instructions appropriate for the computer you are using.
 
 **Open a bash shell.**
-If you are using a computer with running a Unix operating system (i.e. a Mac or Linux computer) you can use the **Terminal** program. If you are on a computer using Windows, open either **WLS** (Windows Linux Subsytem) or **Git Bash**. If you don't have these programs there are instructions for how to download and set them up in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md) module.
+If you are using a computer with running a Unix operating system (i.e. a Mac or Linux computer) you can use the **Terminal** program. If you are on a computer using Windows, open either **WLS** (Windows Linux Subsytem) or **Git Bash**. If you don't have these programs there are instructions for how to download and set them up in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md#windows-computers) module.
 
 <div class = "care">
 <b style="color: rgb(var(--color-highlight));">A little encouragement...</b><br>

--- a/_module_templates/macros_bash.md
+++ b/_module_templates/macros_bash.md
@@ -16,7 +16,7 @@ Previous versions:
 No Previous Versions
 @end
 
-@lesson_prep_bash
+@lesson_prep_bash_basics
 
 You will get the most out of this lesson if you follow along with the examples and try out the commands. In order to do that you need to have a bash shell open on your computer. Please follow the instructions appropriate for the computer you are using.
 
@@ -74,7 +74,8 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 # Bash Module Macros
 
-@lesson_prep_bash
+## Lesson Preparation for Bash Basics Sequence
+@lesson_prep_bash_basics
 
 
 

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -56,6 +56,8 @@ Previous versions:
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_bash.md
+
+import: https://raw.githubusercontent.com/arcus/education_modules/537-docs-v1-update-bash-combine-commands/_module_templates/macros_bash.md
 -->
 
 # Bash: Combining Commands

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -64,7 +64,7 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 ## Lesson Preparation
 
-@lesson_prep_bash
+@lesson_prep_bash_basics
 
 ## Inputs and Outputs
 

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -57,7 +57,6 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_bash.md
 
-import: https://raw.githubusercontent.com/arcus/education_modules/537-docs-v1-update-bash-combine-commands/_module_templates/macros_bash.md
 -->
 
 # Bash: Combining Commands

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -3,7 +3,7 @@
 author:   Elizabeth Drellich and Nicole Feldman
 email:    drelliche@chop.edu and feldmanna@chop.edu
 version: 1.3.1
-current_version_description: Restructure Learning Objectives
+current_version_description: Restructured Learning Objectives
 module_type: standard
 docs_version: 1.3.1
 language: en
@@ -48,8 +48,8 @@ previous_sequential_module: bash_command_line_102
 
 Previous versions: 
 
-- [1.2.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/8e01732bc52d86e63c28ee8ef7abaed2c003cb3f/bash_103_combining_commands/bash_103_combining_commands.md): Correct quiz answer
-- [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/ed49367f50018e9c32c206d30047cee5d4e24a92/bash_103_combining_commands/bash_103_combining_commands.md: Update highlight boxes and clarify instructions
+- [1.2.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/8e01732bc52d86e63c28ee8ef7abaed2c003cb3f/bash_103_combining_commands/bash_103_combining_commands.md): Corrected quiz answer
+- [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/ed49367f50018e9c32c206d30047cee5d4e24a92/bash_103_combining_commands/bash_103_combining_commands.md: Updated highlight boxes and clarified instructions
 - [1.0.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/82883e76e9b41dca4e6caea5734cd518805bd3fe/bash_103_combining_commands/bash_103_combining_commands.md): Initial Version 
 @end
 

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -2,14 +2,22 @@
 
 author:   Elizabeth Drellich and Nicole Feldman
 email:    drelliche@chop.edu and feldmanna@chop.edu
-version: 1.3.0
-module_template_version: 2.0.1
+version: 1.3.1
+current_version_description: 
+module_type: standard
+docs_version: 1.3.1
 language: en
 narrator: UK English Female
 title:  Bash: Combining Commands
 comment:  This module will teach you how to combine two or more commands in bash to create more complicated pipelines in Bash.
 long_description: This module is for learners who can use some basic Bash commands and want to learn to how to use the output of one command as the input for another command.
-estimated_time: 30 minutes
+estimated_time_in_minutes: 30
+
+@pre_reqs
+Learners should be familiar with using a bash shell and [navigating a file system from the command line and look at the contents of a file](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md).
+
+The only commands that will be assumed are the navigation commands `cd`, `ls`, and `pwd` and `cat`, all of which are explained in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md) module.
+@end
 
 @learning_objectives
 
@@ -20,37 +28,37 @@ After completion of this module, learners will be able to:
 - Chain commands directly using the pipe `|`
 @end
 
-link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
+good_first_module: false
+coding_required: true
+coding_level: intermediate
+coding_language: bash
+sequence_name: bash_basics
+previous_sequential_module: bash_command_line_102
 
-script: https://kit.fontawesome.com/83b2343bd4.js
+@sets_you_up_for
+- bash_scripts
+@end
+
+@depends_on_knowledge_in
+- bash_command_line_101
+- bash_command_line_102
+@end
+
+@version_history 
+
+Previous versions: 
+
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
+- [x.x.x](link): that version's current version description
+@end
+
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 -->
 
 # Bash: Combining Commands
 
-<div class = "overview">
-
-## Overview
-
-@comment
-
-**Is this module right for me?**
-
-@long_description
-
-**Estimated time to completion:** @estimated_time
-
-**Pre-requisites**
-
-Learners should be familiar with using a bash shell and [navigating a file system from the command line and look at the contents of a file](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md).
-
-The only commands that will be assumed are the navigation commands `cd`, `ls`, and `pwd` and `cat`, all of which are explained in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md) module.
-
-**Learning Objectives**
-
-@learning_objectives
-
-</div>
-
+@overview
 
 ## Lesson Preparation
 
@@ -501,16 +509,4 @@ These webinars, recorded by Jacob Levernier are a great walk through the command
 
 ## Feedback
 
-In the beginning, we stated some goals.
-
-**Learning Objectives:**
-
-@learning_objectives
-
-We ask you to fill out a brief (5 minutes or less) survey to let us know:
-
-* If we achieved the learning objectives
-* If the module difficulty was appropriate
-* If we gave you the experience you expected
-
-We gather this information in order to iteratively improve our work. Thank you in advance for [filling out our brief survey](https://redcap.chop.edu/surveys/?s=KHTXCXJJ93&module_name=%22Bash+Combining+Commands%22&version=1.0.1)!
+@feedback

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -54,6 +54,8 @@ Previous versions:
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
+
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_bash.md
 -->
 
 # Bash: Combining Commands
@@ -62,55 +64,7 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 ## Lesson Preparation
 
-
-You will get the most out of this lesson if you follow along with the examples and try out the commands. In order to do that you need to have a bash shell open on your computer. Please follow the instructions appropriate for the computer you are using.
-
-**Open a bash shell.**
-If you are using a computer with running iOS (i.e. a Mac) you can use the **Terminal** program. If you are on a computer using Windows, open either **WLS** (Windows Linux Subsytem) or **Git Bash**. If you don't have these programs there are instructions for how to download and set them up in the [Bash / Command Line 101](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md) module.
-
-<div class = "care">
-<b style="color: rgb(var(--color-highlight));">A little encouragement...</b><br>
-
-It can be stressful to interact with files directly from the command line. Throughout this module we will make sure you know what each command does before asking you to do it.  Like any other computational skill, you'll get more comfortable with it the more you practice!
-
-</div>
-
-To ensure that we aren't touching any of the important files on your computer, you will be downloading a small directory to experiment with.  You can download a fresh copy to start over at any point. 
-
-<div class = "warning">
-<b style="color: rgb(var(--color-highlight));">Warning!</b><br>
-
-Please download a fresh copy of these files. If you have downloaded them for a previous module, you have likely moved and changed some of them while working through that module and the examples in this module assume that no changes have already been made to the directory.
-
-</div>
-
-**Download the files.**
-
-Download the [`learning_bash` directory](https://github.com/arcus/learning_bash) from GitHub. Once you go to the link:
-
-1. Click on the green **Code** drop-down button towards the right-hand side of the screen. 
-
-2. Select **Download ZIP** from the options that appear.
-
-3. Once the Zip file has downloaded, un-zipping it will create a folder titled `learning_bash-main`. Depending on your computer's operating system, you may be able to un-zip the folder by double clicking on it, or may need to right click on it a select "Extract All." This may create an identically named folder inside `learning_bash-main` that contains all of the individual files.
-4. [Find out the file path](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md#6) (location on your computer) of the new folder `learning_bash-main` and navigate there in your command line interface.
-
-<div class = "help">
-<b style="color: rgb(var(--color-highlight));">Troubleshooting help</b><br>
-
-**Where is my folder?**
-
-If you can see the icon for your `learning_bash-main` folder (maybe in a downloads screen) you can open your command line interface directly into the folder by right clicking on the folder and selecting the appropriate option:
-
-| Command Line Interface | Right-click menu option |
-| :- | :- |
-| Terminal (Mac or Linux) | New Terminal at Folder |
-| Git Bash (Windows) | Git Bash Here |
-| WLS (Windows Linux Subsystem) | Open Linux shell here |
-
-This will open a command line interface at the correct location. Once there, you can use the command `pwd` to see the path to your present working directory.
-
-</div>
+@lesson_prep_bash
 
 ## Inputs and Outputs
 

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -3,7 +3,7 @@
 author:   Elizabeth Drellich and Nicole Feldman
 email:    drelliche@chop.edu and feldmanna@chop.edu
 version: 1.3.1
-current_version_description: 
+current_version_description: Restructure Learning Objectives
 module_type: standard
 docs_version: 1.3.1
 language: en
@@ -48,9 +48,9 @@ previous_sequential_module: bash_command_line_102
 
 Previous versions: 
 
-- [x.x.x](link): that version's current version description
-- [x.x.x](link): that version's current version description
-- [x.x.x](link): that version's current version description
+- [1.2.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/8e01732bc52d86e63c28ee8ef7abaed2c003cb3f/bash_103_combining_commands/bash_103_combining_commands.md): Correct quiz answer
+- [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/ed49367f50018e9c32c206d30047cee5d4e24a92/bash_103_combining_commands/bash_103_combining_commands.md: Update highlight boxes and clarify instructions
+- [1.0.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/82883e76e9b41dca4e6caea5734cd518805bd3fe/bash_103_combining_commands/bash_103_combining_commands.md): Initial Version 
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md

--- a/docs.md
+++ b/docs.md
@@ -204,6 +204,7 @@ Use the checklist below to help make sure you're including all the front matter 
 - [ ] follows other modules in a sequence (i.e. it's not the first in the sequence)
 - [ ] is parallel to one or more other modules (i.e. covers the same content but in a different coding langauge/operating system)
 - [ ] uses the Data Carpentry genomics AMI on AWS
+- [ ] uses the learning_bash repo
 <script output="module_characteristics">"@input"</script>
 
 You'll need the following fields in your front matter (new fields added by checking boxes above will be followed by 💫): 
@@ -286,6 +287,7 @@ try {
 @add_item(1,import macros_python.md)
 @add_item(2,import macros_sql.md)
 @add_item(10,import macros_genomics.md)
+@add_item(10,import macros_bash.md)
 
 ### `author`
 
@@ -845,6 +847,13 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_genomics.md
 ```
 
+Bash modules that make use of the [learning_bash repo](https://github.com/arcus/learning_bash) will need to import the bash macros as well: 
+
+```
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_bash.md
+```
+
 Modules using interactive R, Python, or SQL will need additional import files (see the sections on [interactive coding](#including-interactive-code) for details).
 
 ## DART macros
@@ -864,6 +873,7 @@ For example, the Overview and Feedback sections of each module are created by th
 - General use macros are in the [module macros file](https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md). This includes macros to generate the overview and feedback sections, as well as general-purpose javascript such as the gifPreload macro. It also loads our icon kit and style sheet. This macro file should be imported in **every module**. 
 - Macros to create the descriptions of external resources for wrapper modules are in the [wrapper macros file](https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_wrapper.md).
 - Macros for genomics modules that use AWS are in the [genomics macros file](https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_genomics.md). This includes a lesson prep macro reminding learners how to connect to their AWS instance and a reminder macro warning them that if they don't terminate their instance when they're done working they'll continue to be charged.
+- A macro providing instructions on how to download the [learning_bash repo](https://github.com/arcus/learning_bash) contents (as well as links to instructions to set up the shell in Mac and Windows) is available in the [bash macros file](https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_bash.md).
 - Macros for hands-on code in R, Python, and SQL modules are available in `macros_r.md`, `macros_python.md`, and `macros_sql.md`, respectively. SQL tables are loaded with additional files. For more details, see the sections on [including interactive code](#including-interactive-code) in this documentation.
 
 For more information about our macros and instructions for writing new ones, see the [macros instructions](https://github.com/arcus/education_modules/blob/main/macros_instructions.md).


### PR DESCRIPTION
This PR updates the front matter to docs v1, and also introduces a new macro for the bash_basics sequence lesson prep.

Line 60 in bash_command_line_103.md can be removed before merging, but doesn't have to be, it just links to the current location of the lesson prep macro.