### PR TITLE
Add commented print command

### DIFF
--- a/pandas_transform/pandas_transform.md
+++ b/pandas_transform/pandas_transform.md
@@ -2,10 +2,10 @@
 
 author:   Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.1.1
+version: 1.1.2
 current_version_description: Update highlight boxes for greater clarity, other minor changes
 module_type: standard
-docs_version: 1.2.0
+docs_version: 2.0.0
 language: en
 narrator: UK English Female
 mode: Textbook

--- a/pandas_transform/pandas_transform.md
+++ b/pandas_transform/pandas_transform.md
@@ -850,6 +850,8 @@ is_male = covid_testing.loc[:, "gender"] == "male"
 
 covid_testing.loc[is_male, "gender"] = "M"
 
+#print(covid_testing.loc[:,["first_name", "last_name", "gender"]])
+
 </script>
 </lia-keep>
 </div>


### PR DESCRIPTION
This fixes #348 by making sure that users don't need to type the complicated print command in themselves, they can just un-comment it.