### PR TITLE
Python basics: Lists and dicts update

### DIFF
--- a/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
+++ b/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
@@ -407,7 +407,7 @@ You might have noticed by now that we have used square brackets in a few differe
     </div>
     ***
 
-2. How would you access all of the counties (the "keys") in the dictionary below? 
+2. How would you access all of the countries (the "keys") in the dictionary below? 
 
     `capital_cities = {"Afghanistan" : "Kabul", "Albania" : "Tirana", "Algeria" : "Algiers", "Andorra" : "Andorra la Vella"}`
 

--- a/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
+++ b/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
@@ -430,7 +430,7 @@ You might have noticed by now that we have used square brackets in a few differe
 
     [[capital_cities["Angola"] = "Luanda"]]
     <script>
-    let input = "@input".trim().replace(/\s/g, "");
+    let input = "@input".replace(/\s/g, "");
     input == 'capital_cities["Angola"]="Luanda"' || input == "capital_cities['Angola']='Luanda'";
     </script>
     ***

--- a/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
+++ b/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
@@ -429,7 +429,10 @@ You might have noticed by now that we have used square brackets in a few differe
     `capital_cities = {"Afghanistan" : "Kabul", "Albania" : "Tirana", "Algeria" : "Algiers", "Andorra" : "Andorra la Vella"}`
 
     [[capital_cities["Angola"] = "Luanda"]]
-    [[?]] If you think the correct answer is being marked wrong, make sure you have one space on each side of the `=` sign. Python doesn't care, but this box does.
+    <script>
+    let input = "@input".trim().replace(/\s/g, "");
+    input == 'capital_cities["Angola"]="Luanda"' || input == "capital_cities['Angola']='Luanda'";
+    </script>
     ***
     <div class = "answer">
 

--- a/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
+++ b/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
@@ -5,7 +5,7 @@ email:    leemc@chop.edu
 version: 1.0.0
 current_version_description: Initial version
 module_type: standard
-docs_version: 1.2.0
+docs_version: 2.0.0
 language: en
 narrator: UK English Female
 mode: Textbook


### PR DESCRIPTION
I added a line that strips all whitespace from the input (not just trimming at the beginning and end) and then matches it to an answer with no spaces. So regardless of what spaces a learner puts in, it will mark it correct. Note that if the learner puts in breaking spaces (e.g. `capital _ cities["Angola"]="Luanda"` or something like that), that will still be marked as correct here. I think that's probably okay though?
I also explicitly put in two different correct answers to match against, with an OR: One using double quotes and one using single quotes. So now it will be marked correct whether learners use double or single quotes. I didn't plan for a learner using both (`capital_cities['Angola']="Luanda"`) because that would be more complex and seemed unlikely, but we could totally put that option in by extending the OR logic.

Fixes #538 Fixes #508 

Fixes #584 fixes #562 (same typo, two issues)