### PR TITLE
Omics aws update

### DIFF
--- a/_module_templates/macros_genomics.md
+++ b/_module_templates/macros_genomics.md
@@ -2,15 +2,51 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  1.0.0
-current_version_description: Initial version.
+version:  2.0.0
+current_version_description: Added macro aws_explanation to provide context for learners about why we're requiring them to set up an AWS account.
 language: en
 narrator: UK English Female
 title: Genomics Module Macros
 comment:  This is placeholder module to save macros used in other modules.
 
 @version_history 
-No previous versions.
+Previous versions: 
+
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/a588227c04699c46112b01bea136679f8d6f7dc0/_module_templates/macros_genomics.md#1): Initial version
+
+@end
+
+@aws_explanation
+
+<div class = "important">
+<b style="color: rgb(var(--color-highlight));">Important note</b><br>
+
+This module includes hands-on genomics analysis examples that are too demanding to run on most personal computers. 
+In order to follow along, you'll need to use Amazon's cloud computing (AWS), which will require you to have an AWS account with a credit card.
+
+</div>
+
+We regret having to rely on a paid service for our learners to practice this code, but unfortunately we have been unable to find a free service that can support the computing power needed for genomics. 
+If you have a suggestion for a free platform we could direct learners to instead of AWS, please [let us know](#feedback)!
+
+We'll continue to look for a better solution, but in the meantime we wanted to make these training materials available in the best way we know how.
+
+<div class = "options">
+<b style="color: rgb(var(--color-highlight));">Another option</b><br>
+
+**What other options do you have?**
+
+You can try to download all of the relevant files and install the necessary software on your computer (there are instructions for doing so in the [Data Carpentry genomics setup instructions](https://datacarpentry.org/genomics-workshop/setup.html)).
+Please note that even for very small genomics analysis examples, the files required are large and it may take hours for you to download them. 
+Even after downloading everything, your computer might not be powerful enough to run the necessary commands without hanging. 
+
+You may have access to powerful cloud computing via your institution. 
+If so, that can be a great option for practicing genomics analysis without having to set up an AWS account. 
+Reach out to your IT team for help accessing and using computing resources at your institution. 
+It may be helpful to share the [Data Carpentry genomics setup instructions](https://datacarpentry.org/genomics-workshop/setup.html) with them to let them know what software you'll need.
+
+</div>
+
 @end
 
 @lesson_prep_ami
@@ -62,6 +98,8 @@ If there are files on your instance that you don't want to lose, be sure to move
 -->
 
 # Genomics Module Macros
+
+@aws_explanation
 
 ## Lesson Preparation
 

--- a/genomics_quality_control/genomics_quality_control.md
+++ b/genomics_quality_control/genomics_quality_control.md
@@ -67,7 +67,7 @@ Previous versions:
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
-import: https://raw.githubusercontent.com/arcus/education_modules/omics_aws_update/_module_templates/macros_genomics.md
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_genomics.md
 -->
 
 # Genomics Tools and Methods: Quality Control

--- a/genomics_quality_control/genomics_quality_control.md
+++ b/genomics_quality_control/genomics_quality_control.md
@@ -2,10 +2,10 @@
 
 author:   Rose Hartman
 email:    hartmanr1@chop.edu
-version:  1.0.0
-current_version_description: Initial version.
+version:  1.1.0
+current_version_description: Add explanation about why we use AWS for genomics modules.
 module_type: standard
-docs_version: 1.1.0
+docs_version: 2.0.0
 language: en
 narrator: UK English Female
 mode: Textbook
@@ -62,7 +62,8 @@ sequence_name: genomics_tools_and_methods
 @version_history 
 
 Previous versions: 
-No previous versions.
+
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/a588227c04699c46112b01bea136679f8d6f7dc0/genomics_quality_control/genomics_quality_control.md#1): Initial version.
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
@@ -84,6 +85,8 @@ Version 2017.11.0, November 2017,
 doi: 10.5281/zenodo.1064254
 
 </div>
+
+@aws_explanation
 
 ## Lesson preparation
 

--- a/genomics_quality_control/genomics_quality_control.md
+++ b/genomics_quality_control/genomics_quality_control.md
@@ -67,7 +67,7 @@ Previous versions:
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
-import: https://raw.githubusercontent.com/arcus/education_modules/omics_tools_and_methods/_module_templates/macros_genomics.md
+import: https://raw.githubusercontent.com/arcus/education_modules/omics_aws_update/_module_templates/macros_genomics.md
 -->
 
 # Genomics Tools and Methods: Quality Control

--- a/genomics_setup/genomics_setup.md
+++ b/genomics_setup/genomics_setup.md
@@ -71,6 +71,7 @@ Previous versions:
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_wrapper.md
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_genomics.md
 -->
 
 # Genomics Tools and Methods: Computing Setup

--- a/genomics_setup/genomics_setup.md
+++ b/genomics_setup/genomics_setup.md
@@ -71,7 +71,7 @@ Previous versions:
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_wrapper.md
-import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_genomics.md
+import: https://raw.githubusercontent.com/arcus/education_modules/omics_aws_update/_module_templates/macros_genomics.md
 -->
 
 # Genomics Tools and Methods: Computing Setup

--- a/genomics_setup/genomics_setup.md
+++ b/genomics_setup/genomics_setup.md
@@ -71,7 +71,7 @@ Previous versions:
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_wrapper.md
-import: https://raw.githubusercontent.com/arcus/education_modules/omics_aws_update/_module_templates/macros_genomics.md
+import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros_genomics.md
 -->
 
 # Genomics Tools and Methods: Computing Setup

--- a/genomics_setup/genomics_setup.md
+++ b/genomics_setup/genomics_setup.md
@@ -2,10 +2,10 @@
 
 author:   Rose Hartman
 email:    hartmanr1@chop.edu
-version:  1.0.0
-current_version_description: Initial version
+version:  1.1.0
+current_version_description: Add explanation for why we use AWS for genomics modules. 
 module_type: wrapper
-docs_version: 1.0.0
+docs_version: 2.0.0
 language: en
 narrator: UK English Female
 mode: Textbook
@@ -64,7 +64,9 @@ coding_language: bash
 @end
 
 @version_history 
-No previous versions.
+Previous versions: 
+
+- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/e5ee3852f80245798baa280f195b806a39122849/genomics_setup/genomics_setup.md#1): Initial version.
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
@@ -83,6 +85,8 @@ We are grateful to the team of authors and maintainers at [Data Carpentry](https
 Erin Alison Becker, Tracy Teal, François Michonneau, Maneesha Sane, Taylor Reiter, Jason Williams, et al. (2019, June). datacarpentry/genomics-workshop: Data Carpentry: Genomics Workshop Overview, June 2019 (Version v2019.06.1). Zenodo. http://doi.org/10.5281/zenodo.3260309
 
 </div>
+
+@aws_explanation
 
 ## Lesson Preparation
 


### PR DESCRIPTION
I created a new macro to include after the overview section of any module using AWS for omics. Hopefully fixes #560 and fixes #620 although of course it would be much better if we had a reliable free option to offer folks. Until we find that, this explanation/apology is the best I could do. :(

So they're handy, here are the liascript links for the two affected modules: 
- [genomics setup](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/omics_aws_update/genomics_setup/genomics_setup.md)
- [genomics quality control](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/omics_aws_update/genomics_quality_control/genomics_quality_control.md)

NOTE: The import statements for the genomics macro file currently point to the version on this branch, for testing. After reviewing, we'll need to change those back to main before merging in both the genomics setup module and the genomics quality control module.