### PR TITLE
Remove links to lab down skill up webinars by jacob levernier

### DIFF
--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -2,10 +2,10 @@
 
 author:   Elizabeth Drellich and Nicole Feldman
 email:    drelliche@chop.edu and feldmanna@chop.edu
-version: 1.3.2
+version: 1.3.3
 current_version_description: Restructured Learning Objectives
 module_type: standard
-docs_version: 1.3.1
+docs_version: 2.0.0
 language: en
 narrator: UK English Female
 mode: Textbook
@@ -456,12 +456,6 @@ Since we don't want to overwrite the text already in `Animals.csv` we have to us
 ## Additional Resources
 
 The [Software Carpentries](https://software-carpentry.org) has a series of lessons on the [Unix Shell](https://swcarpentry.github.io/shell-novice/).
-
-These webinars, recorded by Jacob Levernier are a great walk through the command line.
-
-- [Unix Command Line I Arcus Education Webinar](https://digitalrepository.chop.edu/commandline_computingtools/3/)
-- [Unix Command Line II Arcus Education Webinar](https://digitalrepository.chop.edu/commandline_computingtools/2/)
-- [Intermediate Bash Scripting Arcus Education Webinar](https://digitalrepository.chop.edu/commandline_computingtools/1/)
 
 ## Feedback
 

--- a/bash_scripts/bash_scripts.md
+++ b/bash_scripts/bash_scripts.md
@@ -2,7 +2,7 @@
 
 author:   Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.2.0
+version: 1.2.1
 current_version_description: Updated metadata and macros
 module_type: standard
 docs_version: 2.0.0
@@ -641,9 +641,6 @@ The variable `$string` is called in the last two lines of the script, so the use
 
 - [Exhaustive Wiki of Linux Filesystem Hierarchy](https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/index.html)
 - [Reinforce Your New Knowledge through this Learning the Shell Page](https://linuxcommand.org/lc3_learning_the_shell.php)
-- [Unix Command Line I Arcus Education Webinar](https://digitalrepository.chop.edu/commandline_computingtools/3/)
-- [Unix Command Line II Arcus Education Webinar](https://digitalrepository.chop.edu/commandline_computingtools/2/)
-- [Intermediate Bash Scripting Arcus Education Webinar](https://digitalrepository.chop.edu/commandline_computingtools/1/)
 
 ## Feedback
 


### PR DESCRIPTION
The "lab down skill up" webinar series of videos were all transitioned off of digitalrepository this June. There are new links available via tdnet: https://chop.tdnetdiscover.com/repositories/results?db=299&index=*&fct=Subjects%7Ecommand+line+and+computing+tools%7CSubjects%7Ecommand-line

But those videos are no longer publicly accessible, so we can't use that link in a module. I emailed LS about whether or not we can/should make those links public (the whole video series is possibly being sunsetted this year anyway), but in the meantime this PR removes the reference to those videos since they're inaccessible. Fixes #673 

Note: I searched our whole repo for links to resources on digitalrepository and these two modules were the only ones that came up so I don't think there are any other related links that have the same problem. 

