### PR TITLE
Issue template improvement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Report something broken or not working as expected
+title: ''
+labels: bug
+assignees: ''
+
+---
+<!--
+Note: If this bug was reported via the Quick Module Feedback form, remember to include `record number:` at the top so we can link it back to the original comment if needed, and add the `user-reported` label.
+-->
+
+Description of problem: 
+
+---
+
+**Some things to try first!** 
+
+- If pyodide cells aren't working as expected in Python modules, we may need to update pyodide. 
+- If LiaScript macros aren't rendering properly, especially `@overview`, check for blank macros defined in the front matter (e.g.`version_history` is a common culprit). You may need to add load bearing white space. 
+- If the `feedback` macro isn't working, check that no front matter fields used in the generated REDCap link are missing (e.g. `module_type`).

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,8 +7,10 @@ assignees: ''
 
 ---
 <!--
-Note: If this bug was reported via the Quick Module Feedback form, remember to include `record number:` at the top so we can link it back to the original comment if needed, and add the `user-reported` label.
+Note: If this bug was reported via the Quick Module Feedback form, remember to fill in `record number:` at the top so we can link it back to the original comment if needed, and add the `user-reported` label.
+If this was NOT reported via the Quick Module Feedback form, then feel free to delete the `record number:` line or leave it blank.
 -->
+record number:
 
 Description of problem: 
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -19,3 +19,5 @@ Description of problem:
 - If pyodide cells aren't working as expected in Python modules, we may need to update pyodide. 
 - If LiaScript macros aren't rendering properly, especially `overview`, check for blank macros defined in the front matter (e.g.`version_history` is a common culprit). You may need to add load bearing white space. 
 - If the `feedback` macro isn't working, check that no front matter fields used in the generated REDCap link are missing (e.g. `module_type`).
+- Problems with `div`? You may need a newline after the `div` tag and before the `/div` tag. 
+- Quiz answer boxes not displaying properly? There cannot be a newline between the last answer option and the beginning of the question followup section. Make sure the `****` surrounding the answer div starts immediately after the last line of the question. 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -17,5 +17,5 @@ Description of problem:
 **Some things to try first!** 
 
 - If pyodide cells aren't working as expected in Python modules, we may need to update pyodide. 
-- If LiaScript macros aren't rendering properly, especially `@overview`, check for blank macros defined in the front matter (e.g.`version_history` is a common culprit). You may need to add load bearing white space. 
+- If LiaScript macros aren't rendering properly, especially `overview`, check for blank macros defined in the front matter (e.g.`version_history` is a common culprit). You may need to add load bearing white space. 
 - If the `feedback` macro isn't working, check that no front matter fields used in the generated REDCap link are missing (e.g. `module_type`).

--- a/.github/ISSUE_TEMPLATE/user_reported.md
+++ b/.github/ISSUE_TEMPLATE/user_reported.md
@@ -10,3 +10,8 @@ assignees: ''
 record number: 
 
 Description of issue: (paraphrase user feedback, do not quote)
+
+<!--
+Note: If this involves a bug or broken functionality, consider submitting a big report instead. You'll get suggestions for some known issues and common fixes in the bug report template. :)
+-->
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ In some cases, we will use suggestions we get from the anonymous feedback form t
 
 If you notice content that is factually incorrect, misleading, incomplete, or out of date in one of our modules, please submit an [incorrect info issue report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=incorrect+info&template=issue.md).
 
-If you notice something not working correctly in one of our modules, including things like content not rendering, problems with code, wrong quiz answers, or broken links, please submit a [bug report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=bug&template=issue.md) describing the problem. 
+If you notice something not working correctly in one of our modules, including things like content not rendering, problems with code, wrong quiz answers, or broken links, please submit a [bug report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=bug&template=bug.md) describing the problem. 
 
 If you encounter racist, sexist, ableist, or otherwise offensive material in our modules, or if you find anything about our content or technology to be disabling, please let us know by submitting an [accessibility and inclusion issue report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=a11y&template=issue.md) (which is not anonymous) or by using the link to the feedback form at the end of the affected module (which is anonymous).
 Accessibility and inclusion are important to us; thank you for taking the time to help us improve.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@ Thank you for your interest in our project!
 If you prefer to submit feedback about our modules anonymously, use the survey link in the Feedback section at the end of the affected module. 
 In some cases, we will use suggestions we get from the anonymous feedback form to create new publicly-visible GitHub issues, but we paraphrase everything and take care not to include any potentially identifying information about the person who reported it. 
 
-If you notice something incorrect, misleading, or incomplete in one of our modules, including things like typos, problems with code, wrong quiz answers, broken links, or errors, please submit a [bug report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=bug&template=issue.md) describing the problem. 
+If you notice content that is factually incorrect, misleading, incomplete, or out of date in one of our modules, please submit an [incorrect info issue report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=incorrect+info&template=issue.md).
+
+If you notice something not working correctly in one of our modules, including things like content not rendering, problems with code, wrong quiz answers, or broken links, please submit a [bug report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=bug&template=issue.md) describing the problem. 
 
 If you encounter racist, sexist, ableist, or otherwise offensive material in our modules, or if you find anything about our content or technology to be disabling, please let us know by submitting an [accessibility and inclusion issue report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=a11y&template=issue.md) (which is not anonymous) or by using the link to the feedback form at the end of the affected module (which is anonymous).
 Accessibility and inclusion are important to us; thank you for taking the time to help us improve.
 
-If you notice content that is factually incorrect or out of date in one of our modules, please submit an [incorrect info issue report](https://github.com/arcus/education_modules/issues/new?assignees=&labels=incorrect+info&template=issue.md).
-
-If you have an idea for a way we could improve an existing module by adding new content, please submit a [feature request](https://github.com/arcus/education_modules/issues/new?assignees=&labels=feature+request&template=issue.md) describing your idea.
+If you have an idea for a way we could improve an existing module by adding new content, please submit a [new content request](https://github.com/arcus/education_modules/issues/new?assignees=&labels=new+content&template=issue.md) describing your idea.
 
 ## Proposing a new module
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,14 +20,14 @@ If you have an idea for a way we could improve an existing module by adding new 
 If have an idea for a new module we should write, or if you are interested in writing a module for us, we'd love to hear from you! 
 Please get in touch with us at dart@chop.edu, and review our [instructions on how to create an educational module](https://github.com/arcus/education_modules/blob/main/_for_authors/write_a_module.md). 
 
-## Translating an exisiting module
+## Translating an existing module
 
 If you are interested in helping to translate one or more of our modules into a language other than English, please get in touch with us at dart@chop.edu, and thank you!
 
 ## Adapting or reusing our modules for your own project
 
 All of our content is published under a [creative commons license](#LICENSE).
-We belive in open science, open scholarship, and open education.
+We believe in open science, open scholarship, and open education.
 To make your own copy of all of our modules at once, [fork our repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 If you are using our modules, we'd love to hear about it!


### PR DESCRIPTION
Adding a `bug` issue template, primarily as a way for us to record some of the common problems and quick fixes we've learned about that are currently only stored in our collective memory. 
(As a reminder, the CONTRIBUTING doc will be automatically linked in a popup by GH whenever someone tries to create their first issue in the repo.)