### PR TITLE
Update to docs v2

### DIFF
--- a/r_reshape_long_wide/r_reshape_long_wide.md
+++ b/r_reshape_long_wide/r_reshape_long_wide.md
@@ -4,9 +4,10 @@ email:    paytonk@chop.edu
 version: 1.2.0
 current_version_description: Update highlight boxes, update metadata, and replace text with macros.
 module_type: standard
-docs_version: 1.0.0
+docs_version: 2.0.0
 language: en
 narrator: US English Female
+mode: Textbook
 title: Reshaping Data in R: Long and Wide Data
 comment:  A module that teaches how to reshape tabular data in R, concentrating on some typical shapes known as "long" and "wide" data.
 long_description: Reshaping data is one of the essential skills in getting your data in a tidy format, ready to visualize, analyze, and model.  This module is appropriate for learners who feel comfortable with R basics and are ready to take on the challenges of real life data, which is often messy and requires considerable effort to tidy.
@@ -39,6 +40,7 @@ coding_language: r
 @sets_you_up_for
 
 - r_practice
+- data_visualization_in_ggplot2
 
 @end
 


### PR DESCRIPTION
Brings r reshape long wide up to date with docs v2 (it pretty much already was, but I added the missing metadata field `mode: Textbook` and added one more module to `sets_you_up_for`)