### PR TITLE
Typo fixes for regex flags, boundaries, and anchors

### DIFF
--- a/regular_expressions_boundaries_anchors/regular_expressions_boundaries_anchors.md
+++ b/regular_expressions_boundaries_anchors/regular_expressions_boundaries_anchors.md
@@ -337,7 +337,7 @@ What's the anchor character that indicates the **end of a string**?
 ***
 <div class = "answer">
 
-The anchor for the start of a string is the dollar sign, or `$`, symbol.
+The anchor for the end of a string is the dollar sign, or `$`, symbol.
 
 </div>
 ***

--- a/regular_expressions_boundaries_anchors/regular_expressions_boundaries_anchors.md
+++ b/regular_expressions_boundaries_anchors/regular_expressions_boundaries_anchors.md
@@ -221,8 +221,6 @@ If you're looking for the actual symbol `^` in your text, you'll have to **escap
 
 ### End-of-string Anchoring 
 
-Ok, here is a proposed update that will satisfy my grammar prescriptivism for published materials (I try to be a descriptivist with language but punctuation is more of struggle).
-
 As a reminder, the symbol for end-of-string in a regular expression is `$`.  We can use this symbol to look for specific patterns at the end of strings.  For example, we could look for specific typos that tend to appear at the end of strings: periods that follow something other than a letter or number.  Here are some examples of acceptable grammar and typos:
 
 **Acceptable**

--- a/regular_expressions_boundaries_anchors/regular_expressions_boundaries_anchors.md
+++ b/regular_expressions_boundaries_anchors/regular_expressions_boundaries_anchors.md
@@ -2,7 +2,7 @@
 
 author:   Joy Payton
 email:    paytonk@chop.edu
-version:  1.0.1
+version:  1.0.2
 current_version_description: Initial version
 module_type: standard
 docs_version: 1.0.0


### PR DESCRIPTION
Fixes #726 and also removes a little extra text that got inserted into the module accidentally