### PR TITLE
Add updated links to CLI videos from lab down skill up

### DIFF
--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -458,6 +458,12 @@ Since we don't want to overwrite the text already in `Animals.csv` we have to us
 
 The [Software Carpentries](https://software-carpentry.org) has a series of lessons on the [Unix Shell](https://swcarpentry.github.io/shell-novice/).
 
+These webinars are a great walk through the command line:
+
+- [Unix Command Line I Arcus Education Webinar](https://www.youtube.com/watch?v=2BKwvSyeZis)
+- [Unix Command Line II Arcus Education Webinar](https://www.youtube.com/watch?v=msgeSVHl8ZA)
+- [Intermediate Bash Scripting Arcus Education Webinar](https://www.youtube.com/watch?v=Ops9Bo6yVn0)
+
 ## Feedback
 
 @feedback

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -2,8 +2,8 @@
 
 author:   Elizabeth Drellich and Nicole Feldman
 email:    drelliche@chop.edu and feldmanna@chop.edu
-version: 1.3.5
-current_version_description: Restructured Learning Objectives
+version: 1.4.0
+current_version_description: Added webinar links to additional resources
 module_type: standard
 docs_version: 2.0.0
 language: en
@@ -50,6 +50,7 @@ previous_sequential_module: bash_command_line_102
 
 Previous versions: 
 
+- [1.3.5](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/768ecbb4a71dd338c90d78dab1ee5a6cc7b39581/bash_103_combining_commands/bash_103_combining_commands.md#1): Restructured learning objectives.
 - [1.2.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/8e01732bc52d86e63c28ee8ef7abaed2c003cb3f/bash_103_combining_commands/bash_103_combining_commands.md): Corrected quiz answer
 - [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/ed49367f50018e9c32c206d30047cee5d4e24a92/bash_103_combining_commands/bash_103_combining_commands.md: Updated highlight boxes and clarified instructions
 - [1.0.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/82883e76e9b41dca4e6caea5734cd518805bd3fe/bash_103_combining_commands/bash_103_combining_commands.md): Initial Version 

--- a/bash_scripts/bash_scripts.md
+++ b/bash_scripts/bash_scripts.md
@@ -643,6 +643,12 @@ The variable `$string` is called in the last two lines of the script, so the use
 - [Exhaustive Wiki of Linux Filesystem Hierarchy](https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/index.html)
 - [Reinforce Your New Knowledge through this Learning the Shell Page](https://linuxcommand.org/lc3_learning_the_shell.php)
 
+These webinars are a great walk through the command line:
+
+- [Unix Command Line I Arcus Education Webinar](https://www.youtube.com/watch?v=2BKwvSyeZis)
+- [Unix Command Line II Arcus Education Webinar](https://www.youtube.com/watch?v=msgeSVHl8ZA)
+- [Intermediate Bash Scripting Arcus Education Webinar](https://www.youtube.com/watch?v=Ops9Bo6yVn0)
+
 ## Feedback
 
 @feedback

--- a/bash_scripts/bash_scripts.md
+++ b/bash_scripts/bash_scripts.md
@@ -2,8 +2,8 @@
 
 author:   Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.2.2
-current_version_description: Updated metadata and macros
+version: 1.3.0
+current_version_description: Added webinar links to additional resources
 module_type: standard
 docs_version: 2.0.0
 language: en
@@ -60,6 +60,7 @@ previous_sequential_module: bash_conditionals_loops
 
 Previous versions: 
 
+- [1.2.2](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/768ecbb4a71dd338c90d78dab1ee5a6cc7b39581/bash_scripts/bash_scripts.md#1): Updated metadata and macros
 - [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/3cdfc807be26db43d837de9e325b66c9213a3d5c/bash_scripts/bash_scripts.md): Improved instructions for downloading learning_bash repository.
 - [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/): Initial version.
 @end


### PR DESCRIPTION
Adding links to Jacob Levernier's bash webinars from the lab down skill up series, since we have the links for them on youtube now. Note that Jacob said he'd rather actually not be credited explicitly, so I didn't include his name. 