### PR TITLE
fix version line regex

### DIFF
--- a/.github/scripts/check_versions.sh
+++ b/.github/scripts/check_versions.sh
@@ -5,18 +5,18 @@ awk 'BEGIN { RS = "diff --git" }   # splits diff file such that each file repres
         { 
             if ( $0 ~ /\/dev\/null/ ) # is this a module file being uploaded for the first time? 
                 { 
-                    version_line_indexes=match ($0, /\+version:[^\n]+/) # gets the starting index of where the pattern is matched, sets RSTART to that value, and RLENGTH to the length of pattern match.
+                    version_line_index=match ($0, /\+version:[^\n]+/) # gets the starting index of where the pattern is matched, sets RSTART to that value, and RLENGTH to the length of pattern match.
                     extracted_version_line=substr($0, RSTART, RLENGTH)  # pulls out the substring that matches.
                     system( "version_number=$(echo " extracted_version_line " | tr -d \"\\+version:\"); if [ $version_number != \"1.0.0\" ]; then echo \"New module "$1" version number needs to be 1.0.0\" >> version_issues ; fi  " )
                     # trims the extracted version line to now just contain the version number itself. Checks if it is equal to 1.0.0, and adds message to list of issues if not. 
                 }
             else if ( $0 ~ /\+version:/) # is there a new version line? 
                 { 
-                    version_line_indexes=match ($0, /([+-]version:[^\n]*\n)+/) # gets the starting index of where the pattern is matched, sets RSTART to that value
+                    version_line_index=match ($0, /(-version:.*\+version:[^\n]+)/) # gets the starting index of where the pattern is matched, sets RSTART to that value
+                    # regex used above accounts for the fact that there may be other lines displayed in the diff in between old and new version lines
                     extracted_version_lines=substr($0,RSTART,RLENGTH) # pulls out the substring that matches.
                     system("bash -c '\''issue=$(grep \"[+-]version:\" <<<  \""extracted_version_lines "\"| sed \"s/[+-]version://g\"| bash .github/scripts/version_values_comparison.sh); if [ -n \"$issue\" ]; then echo \""$1": $issue\" >> version_issues ; fi'\''")
-                    # trims ending newline by grepping for only lines with +/- version, then trims the line to just contain version number itself. if issue string is not null (ie, value comparison script returns issue messages), adds messages to list of issues. 
-                    # 
+                    # removes any extra lines from diff by grepping for only lines with +/- version, then trims the line to just contain version number itself. if issue string is not null (ie, value comparison script returns issue messages), adds messages to list of issues. 
                 }
             else
                 {


### PR DESCRIPTION
Fix problem of version incrementation check failing if the old version line and new version line do not appear in immediate sequence of one another in the git diff, as seen in #900, which is currently failing this check. 

adjust regex used to extract lines with version numbers from git diff to account for instances where there are other changed lines that appear in between the display of the old version line and the new version line. also minor variable renaming.