### PR TITLE
update marketplace actions to v4

### DIFF
--- a/.github/workflows/pull_metadata.yml
+++ b/.github/workflows/pull_metadata.yml
@@ -27,14 +27,14 @@ jobs:
     # outputs:
     #   changes: ${{ steps.check_if_changed.outputs.changes }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Process all the metadata using the script for that
       - name: Process Metadata
         run: |
           bash .github/scripts/process_metadata.sh
 
       - name: Upload json file as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: json_artifact
           path: module_data.json
@@ -49,7 +49,7 @@ jobs:
       changes: ${{ steps.check_if_changed.outputs.changes }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: json_artifact
 
@@ -104,10 +104,10 @@ jobs:
           OUTPUT3: ${{needs.run_script.outputs.changes}}
         run: echo "The changes variable is $OUTPUT3"
       
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Download json artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: json_artifact
 
@@ -154,14 +154,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: metadata_changed_message
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build webpage markdown file
         run: |
           bash .github/scripts/public_list_of_modules.sh
       
       - name: Upload webpage file as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webpage_artifact
           path: new_list_of_modules.md
@@ -176,7 +176,7 @@ jobs:
       changes: ${{ steps.check_if_website_changed.outputs.changes }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: webpage_artifact
 
@@ -214,10 +214,10 @@ jobs:
     needs: check_list_of_modules_for_changes
     if: needs.check_list_of_modules_for_changes.outputs.changes == 'true'  
     steps:      
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Download webpage artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: webpage_artifact
 

--- a/.github/workflows/version_incrementation.yml
+++ b/.github/workflows/version_incrementation.yml
@@ -8,7 +8,7 @@ jobs:
   check-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: 
           fetch-depth: 2
       - name: Get git diff to feed to script


### PR DESCRIPTION
update download-artifact, upload-artifact, and checkout to use v4, to address deprecation of node.js 16 actions