### PR TITLE
End auto links with #1

### DIFF
--- a/.github/scripts/public_list_of_modules.sh
+++ b/.github/scripts/public_list_of_modules.sh
@@ -60,7 +60,7 @@ do
         echo $domain
 
         
-        echo "| [$title](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/$FOLDER/$FOLDER.md) | $comment | $estimated_time_in_minutes min| $collection | $coding_language | $task | $domain |" >> $page
+        echo "| [$title](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/$FOLDER/$FOLDER.md#1) | $comment | $estimated_time_in_minutes min| $collection | $coding_language | $task | $domain |" >> $page
 
     fi
 done

--- a/.github/workflows/pull_metadata.yml
+++ b/.github/workflows/pull_metadata.yml
@@ -8,7 +8,7 @@ name: Process Module Metadata
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: "end_auto_links_with_#1" #CHANGE TO MAIN BEFORE MERGING
+    branches: "main" #CHANGE TO MAIN BEFORE MERGING
     paths-ignore:
       - 'assets/**'
       - '_for_authors/**'
@@ -152,7 +152,7 @@ jobs:
   generate_webpage_markdown:
     name: Website - Generate page
     runs-on: ubuntu-latest
-    #needs: metadata_changed_message
+    needs: metadata_changed_message
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull_metadata.yml
+++ b/.github/workflows/pull_metadata.yml
@@ -152,7 +152,7 @@ jobs:
   generate_webpage_markdown:
     name: Website - Generate page
     runs-on: ubuntu-latest
-    needs: metadata_changed_message
+    #needs: metadata_changed_message
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull_metadata.yml
+++ b/.github/workflows/pull_metadata.yml
@@ -8,7 +8,7 @@ name: Process Module Metadata
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: "main" #CHANGE TO MAIN BEFORE MERGING
+    branches: "end_auto_links_with_#1" #CHANGE TO MAIN BEFORE MERGING
     paths-ignore:
       - 'assets/**'
       - '_for_authors/**'


### PR DESCRIPTION
This will make sure that all of the auto generated links on the DART website end in `.md#1` so they land on the overview page.