### PR TITLE
Styling bash code blocks in bash modules

### DIFF
--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -2,8 +2,8 @@
 module_id: bash_103_combining_commands
 author:   Elizabeth Drellich and Nicole Feldman
 email:    drelliche@chop.edu and feldmanna@chop.edu
-version: 1.4.5
-current_version_description: Added webinar links to additional resources; make liascript link(s) point to first page
+version: 1.5.0
+current_version_description: Distinguish bash input and output code blocks
 module_type: standard
 docs_version: 2.0.0
 language: en
@@ -49,10 +49,9 @@ previous_sequential_module: bash_command_line_102
 
 Previous versions: 
 
+- [1.4.5](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/d367a7d5a0e9b6abdf67883b31d4a8894a13b17a/bash_103_combining_commands/bash_103_combining_commands.md#1): Added webinar links to additional resources; make liascript link(s) point to first page
 - [1.3.5](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/768ecbb4a71dd338c90d78dab1ee5a6cc7b39581/bash_103_combining_commands/bash_103_combining_commands.md#1): Restructured learning objectives.
 - [1.2.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/8e01732bc52d86e63c28ee8ef7abaed2c003cb3f/bash_103_combining_commands/bash_103_combining_commands.md#1): Corrected quiz answer
-- [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/ed49367f50018e9c32c206d30047cee5d4e24a92/bash_103_combining_commands/bash_103_combining_commands.md#1): Updated highlight boxes and clarified instructions
-- [1.0.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/82883e76e9b41dca4e6caea5734cd518805bd3fe/bash_103_combining_commands/bash_103_combining_commands.md#1): Initial Version 
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
@@ -92,8 +91,11 @@ The `learning_bash` folder contains a few different types of files and folders f
 
 The word count command `wc` takes a file (or files) as input and returns some basic metadata:
 
-```
+```bash
 wc Animals.csv
+```
+
+```+output
       20      36     355 Animals.csv
 ```
 
@@ -122,8 +124,10 @@ For all of the files in this lesson, the number of bytes is the same as the numb
 
 You can also pass multiple files to the `wc` command. It will print out the word count for each, and then helpfully total each column for you at the bottom:
 
-```
+```bash
 wc wolf.txt dog.txt
+```
+```+output
       1       2      12 wolf.txt
       1       3      23 dog.txt
       2       5      35 total
@@ -134,13 +138,13 @@ You might also want to look at the contents of a file. The `cat` command lets yo
 
 The command `head` outputs the first 10 lines of a file. You can ask for the first `n` lines by using the flag `-n`:
 
-```
+```bash
 head -3 Animals.csv
 ```
 
 You should see these first three lines of `Animals.csv`:
 
-```
+```+output
 blue and yellow macaw,bird
 blue jay,bird
 blue whale,mammal
@@ -150,13 +154,13 @@ The `head` command is particularly useful when you know a certain type of inform
 
 The `tail` command is similarly used to output the last lines of a file:
 
-```
+```bash
 tail -4 Animals.csv
 ```
 
 You should see these last four lines of `Animals.csv`:
 
-```
+```+output
 tiger,mammal
 wolf,mammal
 blue morpho,insect
@@ -173,13 +177,13 @@ The `sort` command outputs the lines of a file in alphabetical order, the same o
 
 **Give it a try** in your command line interface:
 
-```
+```bash
 sort Animals.csv
 ```
 
 You can change how the lines are ordered using flags. The `-r` flag reverses the order. Try it out:
 
-```
+```bash
 sort -r Animals.csv
 ```
 <div class = "behind-the-scenes">
@@ -210,19 +214,19 @@ The "greater than" symbol, also known as an arrow or more specifically "right ar
 
 Try running the following code:
 
-```
+```bash
 wc Animals.csv > animals.txt
 ```
 
 You won't see any output because it was redirected to the newly created file `animals.txt`. Use `cat` or another program to check that the file `animals.txt` contains the text:
 
-```
+```+output
       20      36     355 Animals.csv
 ```
 
 A single arrow will replace anything that was already in the file with the new content. If we don't want to replace the content in `animals.txt` we can append (add new lines after the existing lines) to the end of the file using double arrows `>>`:
 
-```
+```bash
 sort Animals.csv >> animals.txt
 ```
 
@@ -239,7 +243,7 @@ In the Bash language, right arrows `>` redirect output, and left arrows `<` redi
 
 Suppose you have acquired a new file with the uninformative name `newfile.txt`. You look at its contents and see that `cat newfile.txt` returns
 
-```
+```+output
 Callinectes sapidus
 
 blue crab,crustacean
@@ -308,7 +312,7 @@ The pipe symbol `|` is like the arrow symbols `>` and `>>` in that it redirects 
 
 In the previous section we learned how to sort the lines in the file `Animals.csv`. But maybe we only care about the last 3 animals listed alphabetically. With a pipe we can first `sort` and then immediately look at the `tail`. Give it a try:
 
-```
+```bash
 sort Animals.csv | tail -3
 ```
 
@@ -316,7 +320,7 @@ You get the last three animals of the alphabetically sorted list: red panda, tig
 
 What do you think will happen if you switch the order of `sort` and `tail`? Try it out:
 
-```
+```bash
 tail -3 Animals.csv | sort
 ```
 Now the blue morpho butterfly is first, instead of the red panda because the last three lines of `Animals.csv` were wolf, blue morpho, and koala.
@@ -325,7 +329,7 @@ Now the blue morpho butterfly is first, instead of the red panda because the las
 
 You can also pipe commands and then write the final output to a file. For example we could create a new file with just the last three alphabetical animals from `Animals.csv`.
 
-```
+```bash
 sort Animals.csv | tail -3 > last.txt
 ```
 
@@ -333,13 +337,17 @@ This command doesn't give any output, but take a look at the contents of your ne
 
 The double arrow `>>` which appends output to a file can also be combined with pipes. Try this line:
 
-```
+```bash
 tail -3 Animals.csv | sort >> last.txt
 ```
 
 Now the file `last.txt` should contain six lines:
 
+```bash
+cat last.txt
 ```
+
+```+output
 red panda,mammal
 tiger,mammal
 wolf,mammal
@@ -352,13 +360,13 @@ wolf,mammal
 
 Now that the file `last.txt` has some repeated lines in it, we can get useful information out of the command `uniq`. This command outputs the lines of a file, but only those lines that are distinct from the line directly above.
 
-```
+```bash
 uniq last.txt
 ```
 
 Since all lines in `last.txt` are different from the line immediately preceding them, this isn't particularly useful. However when combined with the `sort` function, we can eliminate repeated lines:
 
-```
+```bash
 sort last.txt | uniq
 ```
 
@@ -366,7 +374,7 @@ Now there are no repeated lines! They are also in alphabetical order since we fi
 
 If we want to know how many copies of each line were in the original file, the option `-c` for "count" will output the lines with each preceded by the number of occurrences:
 
-```
+```bash
 sort last.txt | uniq -c
 ```
 
@@ -376,7 +384,7 @@ Piping the output of one command into another is extremely powerful, and chainin
 
 Maybe you want to know how many unique animals are in the file `last.txt`. We saw on the last page how to output the list of unique lines using `sort` followed by `uniq`. If we want to know how many (unique) lines there are, we can use the word count function `wc` with the option `-l` for number of lines:
 
-```
+```bash
 sort last.txt | uniq | wc -l
 ```
 
@@ -390,8 +398,10 @@ What if we want to know which animal has the shortest scientific name? This also
 
 Putting these steps together:
 
-```
+```bash
 wc -m *.txt | sort -n | head -1
+```
+```+output
       10 indian_cobra.txt
 ```
 The Indian cobra, scientific name _Naja naja_ has the shortest character count of any of the animals listed here.
@@ -411,7 +421,7 @@ You can chain as many commands as you want into a pipeline, including search com
 
 Let's return to the uninformatively named `newfile.txt`:
 
-```
+```+output
 Callinectes sapidus
 
 blue crab,crustacean
@@ -437,7 +447,7 @@ What command would append the 3rd line, which reads `blue crab,crustacean` to th
 
 The first three lines are returned by `head -3 newfile.txt`:
 
-```
+```+output
 Callinectes sapidus
 
 blue crab,crustacean
@@ -445,7 +455,7 @@ blue crab,crustacean
 
 and the last line of that text is returned by `tail -1`:
 
-```
+```+output
 blue crab,crustacean
 ```
 

--- a/bash_103_combining_commands/bash_103_combining_commands.md
+++ b/bash_103_combining_commands/bash_103_combining_commands.md
@@ -295,7 +295,7 @@ The output of `tail -2 newfile.txt` is the last two lines of `newfile.txt`. Sinc
 
 We could link commands by writing the output of one command to a file, and then running another command on that file. However if we don't actually need that intermediate file it is possible to speed up the process by passing the output of one command directly to another using a "pipe."
 
-The vertical line `|` is called a **pipe**. On American qwerty keyboards symbol `|` is located on the same key as the backslash ` \ ` and can be typed by using the `shift` key with ` \ `.
+The vertical line `|` is called a **pipe**. On American qwerty keyboards the symbol `|` is located on the same key as the backslash ` \ ` and can be typed by using the `shift` key with ` \ `.
 
 <div class = "help">
 <b style="color: rgb(var(--color-highlight));">Troubleshooting help</b><br>

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -195,18 +195,21 @@ Just like when you navigate any file system, it is important to know where you a
 The command `pwd`, which stands for **p**resent **w**orking **d**irectory, will return the path through your directory system to your current location. Here is what I see when I type the command `pwd`.  Depending on your computer setup, you will probably see something similar:
 
 ```bash
-(base) C02GM4SBQ05N:~ drelliche$ pwd
+(base) 1234567890AB:~ drelliche$ pwd
 ```
 
 ```+output
 /Users/drelliche
 ```
+
+The second of the two boxes above, which includes the word "output", shows one example of the kind of output you might see when the command above it is entered.  You can click on the word "output" to collapse the output box if you like. We will use this format for showing the output of commands throught this lesson.
+
 **What is here?**
 
 The bash shell isn't like a graphical file browser:  it doesn't show images or icons that represent the files and directories in your present working directory. Instead, you will need to ask for a **l**i**s**t of the directory's contents with the command `ls`. Here is what I see when I type the command `ls`, you will see something similar:
 
 ```bash
-(base) C02GM4SBQ05N:~ drelliche$ ls
+(base) 1234567890AB:~ drelliche$ ls
 ```
 
 ```+output
@@ -222,7 +225,7 @@ Pictures
 Public
 ```
 
-At this point, you'll start to see output boxes that include the word "output", which show one example of the kind of output you might see when the command above is entered.  You can click on the word "output" to collapse the output boxes if you like. Going forward, we will omit the command prompt from the input and just show you the code to enter, like:
+Going forward, we will omit the command prompt from the input and just show you the code to enter, like:
 
 ```bash
 pwd

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -173,13 +173,13 @@ Bash, or shell, scripting is a way to interface with your computer's operating s
 
 If you are new to bash scripting, it can take some adjustment to navigate by typing text. Once you get the hang of a few basic commands, this can be an easier way to deal with files and folders than dropdown menus and dragging icons from place to place. Even the language we use is a little different. In bash scripting you will hear folders referred to as **directories**.
 
-When you first open a shell, you will see a [**Command Prompt**](https://en.wikipedia.org/wiki/Command-line_interface#Command_prompt). This may look different for everyone, for example the two authors of this module see different things. One of us sees:
+When you first open a shell, you will see a [**Command Prompt**](https://en.wikipedia.org/wiki/Command-line_interface#Command_prompt). This may look different for everyone, for example the two authors of this module see different things. One of us sees the name of their computer followed by a couple of symbols and then their username, all ending with a money symbol.
 
 ```
 (base) C02GM4SBQ05N:~ drelliche$ 
 ```
 
-and the other sees: 
+and the other sees similar information, but in a different order, with different extra symbols to separate the fields.
 
 ![Home directory of the shell in the default homebrew theme.](media/shell_home.png)
 
@@ -192,7 +192,7 @@ Just like when you navigate any file system, it is important to know where you a
 
 **Where am I?**
 
-The command `pwd`, which stands for **p**resent **w**orking **d**irectory, will return the path through your directory system to your current location. Here is what I see when I type the command `pwd`, you will see something similar:
+The command `pwd`, which stands for **p**resent **w**orking **d**irectory, will return the path through your directory system to your current location. Here is what I see when I type the command `pwd`.  Depending on your computer setup, you will probably see something similar:
 
 ```bash
 (base) C02GM4SBQ05N:~ drelliche$ pwd
@@ -203,7 +203,7 @@ The command `pwd`, which stands for **p**resent **w**orking **d**irectory, will 
 ```
 **What is here?**
 
-The bash shell doesn't show the icons of the files and directories in your present working directory. Instead you will need to ask for a list of the directory's contents with the command `ls`. Here is what I see when I type the command `ls`, you will see something similar:
+The bash shell isn't like a graphical file browser:  it doesn't show images or icons that represent the files and directories in your present working directory. Instead, you will need to ask for a **l**i**s**t of the directory's contents with the command `ls`. Here is what I see when I type the command `ls`, you will see something similar:
 
 ```bash
 (base) C02GM4SBQ05N:~ drelliche$ ls
@@ -222,7 +222,7 @@ Pictures
 Public
 ```
 
-You can click on the word "output" to collapse the output boxes. Going forward, we will omit the command prompt from the input and just show you the code to enter, like:
+At this point, you'll start to see output boxes that include the word "output", which show one example of the kind of output you might see when the command above is entered.  You can click on the word "output" to collapse the output boxes if you like. Going forward, we will omit the command prompt from the input and just show you the code to enter, like:
 
 ```bash
 pwd

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -202,7 +202,7 @@ The command `pwd`, which stands for **p**resent **w**orking **d**irectory, will 
 /Users/drelliche
 ```
 
-The second of the two boxes above, which includes the word "output", shows one example of the kind of output you might see when the command above it is entered.  You can click on the word "output" to collapse the output box if you like. We will use this format for showing the output of commands throught this lesson.
+The second of the two boxes above, which includes the word **output**, shows one example of the kind of output you might see when the command above it is entered.  You can click on the word "output" to collapse the output box if you like. We will use this format for showing the output of commands throught this lesson.
 
 **What is here?**
 

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -318,7 +318,7 @@ A [**plain text**](https://en.wikipedia.org/wiki/Plain_text) file is a file that
 <div class = "behind-the-scenes">
 <b style="color: rgb(var(--color-highlight));">Behind the scenes</b><br>
 
-Even though the words "plain text" in the previous paragraph have some non-text attributes, they are all recorded as plain text in the Markdown (`.md`) file of this lesson. If you open the [Markdown file](https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md), you will see only characters that can be typed by a keyboard:
+Even though the words "plain text" in the previous paragraph have some non-text attributes, they are all recorded as plain text in the Markdown (`.md`) file of this lesson. If you open the [Markdown file](https://raw.githubusercontent.com/arcus/education_modules/main/bash_command_line_101/bash_command_line_101.md), everything is text. For example, this is the text we'd write to create a bolded hyperlink:
 
 ```
 [**plain text**](https://en.wikipedia.org/wiki/Plain_text)

--- a/bash_command_line_101/bash_command_line_101.md
+++ b/bash_command_line_101/bash_command_line_101.md
@@ -2,8 +2,8 @@
 module_id: bash_command_line_101
 author:   Nicole Feldman and Elizabeth Drellich
 email:    feldmanna@chop.edu drelliche@chop.edu
-version: 1.5.7
-current_version_description: Updated metadata and macros; make liascript link(s) point to first page
+version: 1.6.0
+current_version_description: Distinguish bash input and output code blocks, clarify command prompts
 module_type: standard
 docs_version: 2.0.0
 language: en
@@ -46,9 +46,9 @@ sequence_name: bash_basics
 
 Previous versions: 
 
+- [1.5.7](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/d367a7d5a0e9b6abdf67883b31d4a8894a13b17a/bash_command_line_101/bash_command_line_101.md#1): Updated metadata and macros; make liascript link(s) point to first page
 - [1.4.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/3cdfc807be26db43d837de9e325b66c9213a3d5c/bash_command_line_101/bash_command_line_101.md#1): Added less command and expanded on man and --help
 - [1.3.2](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/ba1dba7a4c1d4393ae8b42346fe5c69d587b8ee6/bash_command_line_101/bash_command_line_101.md#1): Removed references to sunsetted text editor Atom
-- [1.2.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/466799a081d2cb74d155dc0a26951d3492b81f8c/bash_command_line_101/bash_command_line_101.md#1): Fixed quiz answer boxes
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
@@ -173,9 +173,18 @@ Bash, or shell, scripting is a way to interface with your computer's operating s
 
 If you are new to bash scripting, it can take some adjustment to navigate by typing text. Once you get the hang of a few basic commands, this can be an easier way to deal with files and folders than dropdown menus and dragging icons from place to place. Even the language we use is a little different. In bash scripting you will hear folders referred to as **directories**.
 
-To enter a command into the shell, type it in where the blinking cursor appears and press `Enter` or `return` on your keyboard.
+When you first open a shell, you will see a [**Command Prompt**](https://en.wikipedia.org/wiki/Command-line_interface#Command_prompt). This may look different for everyone, for example the two authors of this module see different things. One of us sees:
+
+```
+(base) C02GM4SBQ05N:~ drelliche$ 
+```
+
+and the other sees: 
 
 ![Home directory of the shell in the default homebrew theme.](media/shell_home.png)
+
+To enter a command into the shell, type it in where the (possibly blinking) cursor appears and press `Enter` or `return` on your keyboard.
+
 
 ### Navigation Commands
 
@@ -183,18 +192,24 @@ Just like when you navigate any file system, it is important to know where you a
 
 **Where am I?**
 
-The command `pwd`, which stands for **p**resent **w**orking **d**irectory, will return the path through your directory system to your current location.
+The command `pwd`, which stands for **p**resent **w**orking **d**irectory, will return the path through your directory system to your current location. Here is what I see when I type the command `pwd`, you will see something similar:
 
-```
+```bash
 (base) C02GM4SBQ05N:~ drelliche$ pwd
+```
+
+```+output
 /Users/drelliche
 ```
 **What is here?**
 
-The bash shell doesn't show the icons of the files and directories in your present working directory. Instead you will need to ask for a list of the directory's contents with the command `ls`.
+The bash shell doesn't show the icons of the files and directories in your present working directory. Instead you will need to ask for a list of the directory's contents with the command `ls`. Here is what I see when I type the command `ls`, you will see something similar:
 
-```
+```bash
 (base) C02GM4SBQ05N:~ drelliche$ ls
+```
+
+```+output
 Applications
 Desktop
 Documents
@@ -205,6 +220,18 @@ Music
 OneDrive - Children's Hospital of Philadelphia
 Pictures
 Public
+```
+
+You can click on the word "output" to collapse the output boxes. Going forward, we will omit the command prompt from the input and just show you the code to enter, like:
+
+```bash
+pwd
+```
+
+or
+
+```bash
+ls
 ```
 
 **How do I navigate around?**
@@ -339,14 +366,14 @@ Make sure you are in your home directory with `pwd`. If not, `cd ~` will get you
 
 **Making a new directory**
 
-The command `mkdir` will create a new directory in your current location. Let's make a new directory called `learning_bash`:
+The command `mkdir` will create a new directory in your current location. Let's make a new directory called `learning_bash`. Enter these two lines of code into your CLI, and hit `Enter` or `Return` after each line to execute the code.
 
-```
+```bash
 cd ~
 mkdir learning_bash
 ```
 
-You will now see `learning_bash` when you ask for the list of files and directories with `ls`, and can use `cd` to navigate into it.
+These two lines won't give you any output, but you will now see `learning_bash` when you ask for the list of files and directories with `ls`, and can use `cd` to navigate into it.
 
 **Creating a new file**
 
@@ -354,14 +381,14 @@ The command `touch` creates a new file. You need to give your file a name.
 
 From your `learning_bash` directory create a new file called `my_file`:
 
-```
+```bash
 cd ~/learning_bash
 touch my_file
 ```
 
 You can also create multiple files at a time by listing their unique names one after another:
 
-```
+```bash
 cd ~/learning_bash
 touch file_1 file_2 file_3
 ```
@@ -393,19 +420,19 @@ The bash command `>>` is used to write the output of a command to the end of a f
 
 For example the following code will create a file called `my_sentences` and write the text `This is a sentence.` in that file.
 
-```
+```bash
 echo "This is a sentence." >> my_sentences
 ```
 
 If you then want to add an additional line to `my_sentences` you can use the same method.
 
-```
+```bash
 echo "This is another sentence." >> my_sentences
 ```
 
 Now the file `my_sentences` has two lines:
 
-```
+```+output
 This is a sentence.
 This is another sentence.
 ```
@@ -433,8 +460,13 @@ The easiest way to see the contents of a short file is the `cat` function. If yo
 
 **Give it a try:**
 
-```
+```bash
 cat my_sentences
+```
+
+```+output
+This is a sentence.
+This is another sentence.
 ```
 
 <div class = "learn-more">
@@ -584,7 +616,7 @@ Entering `man command_name` reveals the documentation for the function `command_
 <div class = "help">
 <b style="color: rgb(var(--color-highlight));">Troubleshooting help</b><br>
 
-The bash manual is not available in Git Bash. If you are using Git Bash, an internet search for "`command_name` bash manual" will usually get you the same information.
+**The bash manual is not available in Git Bash.** If you are using Git Bash, an internet search for "`command_name` bash manual" will usually get you the same information.
 
 </div> 
 

--- a/bash_command_line_102/bash_command_line_102.md
+++ b/bash_command_line_102/bash_command_line_102.md
@@ -2,8 +2,8 @@
 module_id: bash_command_line_102
 author:   Nicole Feldman and Elizabeth Drellich
 email:    feldmanna@chop.edu and drelliche@chop.edu
-version: 1.3.4
-current_version_description: Add emphasis about the permanence of `rm`; make liascript link(s) point to first page
+version: 1.4.0
+current_version_description: Distinguish bash input and output code blocks
 module_type: standard
 docs_version: 3.0.0
 language: en
@@ -55,9 +55,12 @@ previous_sequential_module: bash_command_line_101
 @end
 
 @version_history
+
+Previous Versions
+
+- [1.3.4](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/d367a7d5a0e9b6abdf67883b31d4a8894a13b17a/bash_command_line_102/bash_command_line_102.md#1): Add emphasis about the permanence of `rm`; make liascript link(s) point to first page
 - [1.2.2](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/768ecbb4a71dd338c90d78dab1ee5a6cc7b39581/bash_command_line_102/bash_command_line_102.md#1): Updated module metadata
 - [1.1.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/82883e76e9b41dca4e6caea5734cd518805bd3fe/bash_command_line_102/bash_command_line_102.md#1) Improved Lesson Preparation instructions
-- [1.0.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/738a57ce41189c219ae9288bed4fbde834bb46d4/bash_command_line_102/bash_command_line_102.md#1) Initial version
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md
@@ -78,7 +81,7 @@ Before we start searching for specific things in this directory, let's navigate 
 
 Make sure to replace `~/your/file/path/here/` with the path to `learning_bash-main` on your own computer that you identified on the previous page.
 
-```
+```bash
 cd ~/your/file/path/here/learning_bash-main
 ls
 ```
@@ -104,8 +107,11 @@ It is also a good idea to take a look at what each type of file contains. We wou
 
 If we take a look at the contents of a `.txt` file, we see a few words in Latin.
 
-```
+```bash
 cat dog.txt
+```
+
+```+output
 Canis lupus familiaris
 ```
 
@@ -113,8 +119,11 @@ It looks like the `.txt` files contain the scientific names of the animals! Try 
 
 What is in the `.dat` files?
 
-```
+```bash
 cat blue_whale.dat
+```
+
+```+output
 Length: 29.9 m
 Weight: 190000 kg
 ```
@@ -174,12 +183,12 @@ The command `grep` (rhymes with "step") is a search function to locate a string 
 
 For example if you wanted to search for `bear` in `Animals.csv` you can run the following command:
 
-```
+```bash
 grep 'bear' Animals.csv
 ```
 This will print out each line of `Animals.csv` that contains the string `bear`:
 
-```
+```+output
 black bear,mammal
 grizzly bear,mammal
 panda bear,mammal
@@ -188,25 +197,25 @@ polar bear,mammal
 
 You could also search several files at a time by listing their file names one after another.
 
-```
+```bash
 grep 'Ursus' black_bear.txt grizzly_bear.txt panda_bear.txt
 ```
 
 This will return the files containing `Ursus` as well as each of the lines containing the word.
 
-```
+```+output
 black_bear.txt:Ursus americanus
 grizzly_bear.txt:Ursus arctos horribilis
 ```
 
 We can make `grep` more powerful by combining it with the `*` we used before. You might have noticed that we didn't search `polar_bear.txt` for the word `Ursus`. It would be a lot easier to just search all of the files that contain `bear` for the word `Ursus`. We can do that!
 
-```
+```bash
 grep 'Ursus' *bear*
 ```
 This output will include the files we saw before as well as the previously missing `polar_bear` file.
 
-```
+```+output
 black_bear.txt:Ursus americanus
 grizzly_bear.txt:Ursus arctos horribilis
 polar_bear.txt:Ursus maritimus
@@ -268,7 +277,7 @@ The `mv` command will move files from their current location to a new location. 
 
 To move `blue_jay.txt` to `blue_animals` run the command:
 
-```
+```bash
 mv blue_jay.txt blue_animals
 ```
 
@@ -278,7 +287,7 @@ Notice that we used the **relative** locations of `blue_animals` and the `blue_j
 
 **Tip: You can scroll sideways to see all of the text in the code block:**
 
-```
+```bash
 mv ~/your/file/path/here/learning_bash-main/blue_animals/blue_morpho.txt ~/your/file/path/here/learning_bash-main
 ```
 
@@ -290,7 +299,7 @@ Make sure to replace `~/your/file/path/here/` with the path to `learning_bash-ma
 
 You can also move multiple files at a time by entering them one after another, as long as the directory you want them to end up in is at the end.
 
-```
+```bash
 mv blue_and_yellow_macaw.txt blue_morpho.txt blue_animals
 ```
 
@@ -302,7 +311,7 @@ Did you get a message informing you that "No such file or directory" exists? Mak
 
 We can also use the `*` to move all files and folders matching a certain pattern to a new location. Let's make a new folder containing all files pertaining to blue whales:
 
-```
+```bash
 mkdir blue_whale_folder
 mv blue_whale.* blue_whale_folder
 ```
@@ -310,13 +319,13 @@ This will move both `blue_whale.txt` and `blue_whale.dat` into the folder `blue_
 
 Similarly we could move all of the files and folders that start with the word blue into `blue_animals`.
 
-```
+```bash
 mv blue* blue_animals
 ```
 
 You will get an output warning you that one of the things you asked for cannot be done:
 
-```
+```+output
 mv: rename blue_animals to blue_animals/blue_animals: Invalid argument
 ```
 
@@ -328,7 +337,7 @@ While there is a specific function for renaming files and folders, the easiest w
 
 Maybe we want to rename `koala.txt` to be `koala_bear.txt`. The `mv` function lets us do this by simply moving the file currently named `koala.txt` to a new file in the same location called `koala_bear.txt`:
 
-```
+```bash
 mv koala.txt koala_bear.txt
 ```
 
@@ -337,7 +346,7 @@ mv koala.txt koala_bear.txt
 
 You can also use the global location names for your files or folders. In the example above we could have gotten the same result with
 
-```
+```bash
 mv ~/your/file/path/here/learning_bash-main/koala.txt ~/your/file/path/here/learning_bash-main/koala_bear.txt
 ```
 
@@ -349,7 +358,7 @@ The benefit to using the global names is that you can run commands with global n
 
 The copy function `cp` has the same requirements as the `mv` function: **which file** you want to copy, and **where** you want the copy to go. For example maybe we want to make a new folder called `true_bears` for bears in the genus Ursus, and put copies of those files into the folder while keeping the originals.
 
-```
+```bash
 mkdir true_bears
 cp black_bear.txt true_bears
 ```
@@ -358,7 +367,7 @@ There are now two files with the name `black_bear.txt` but because they are in d
 
 You can also use `cp` to make a copy of a file with a new name. Brown bear is another name for a grizzly bear.
 
-```
+```bash
 cp grizzly_bear.txt brown_bear.txt
 ```
 
@@ -366,7 +375,7 @@ Now there are two files with the same contents but different names.
 
 You can also use the asterisk `*` to speed copy all files with certain patterns in their names.
 
-```
+```bash
 mkdir red_animals
 cp red* red_animals
 ```
@@ -379,20 +388,20 @@ In order to copy a directory using `cp` you need to include the flag `-r` which 
 
 Let's make a new directory for all of the animals with colors in their names.
 
-```
+```bash
 mkdir color_name_animals
 ```
 
 If we want to copy the entire directory of `blue_animals` into this new folder, we need to use the `-r` flag:
 
-```
+```bash
 cp -r blue_animals color_name_animals
 ```
 
 <div class = "important">
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>
 
-Moving a directory with `mv` will move all of its contents to the new location.
+Moving a directory with `mv` will move all of its contents to the new location. 
 
 Copying a directory with `cp` requires the `-r` flag in order to copy all of its contents.
 </div>
@@ -440,7 +449,7 @@ If you are done with a file and sure you won't need it ever again, it might make
 
 The command `rm` **remove**s files listed after it from your computer. Maybe you don't actually want two different names for the same species of bear and want to delete the `brown_bear.txt` file we made earlier:
 
-```
+```bash
 rm brown_bear.txt
 ```
 
@@ -457,7 +466,7 @@ If you are sure you want to delete a directory, the recursive flag `-r` will rec
 
 Maybe you no longer want a `red_animals` folder since all of its contents are available elsewhere:
 
-```
+```bash
 rm -r red_animals
 ```
 

--- a/bash_command_line_102/bash_command_line_102.md
+++ b/bash_command_line_102/bash_command_line_102.md
@@ -103,7 +103,7 @@ A few things we can see from this list of files:
 2. There are `.txt`, `.dat` and `.csv` files.
 3. The `.csv` file is named `Animals.csv` and each of the `.txt` and `.dat` files has the name of an animal.
 
-It is also a good idea to take a look at what each type of file contains. We would expect `Animals.csv` to be some sort of tabular data with rows and columns. You can use `cat` to display the file and confirm this.
+It is also a good idea to take a look at what each type of file contains. We would expect `Animals.csv` to be some sort of tabular data with rows and columns. You can use `cat` to display the file and confirm this. Throught this lesson, the results of each command will be shown in their own collapsible code block labeled **output**.
 
 If we take a look at the contents of a `.txt` file, we see a few words in Latin.
 

--- a/bash_conditionals_loops/bash_conditionals_loops.md
+++ b/bash_conditionals_loops/bash_conditionals_loops.md
@@ -2,8 +2,8 @@
 module_id: bash_conditionals_loops
 author:   Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.2.7
-current_version_description: Clarify `=` and `==` inside test functions; make liascript link(s) point to first page
+version: 1.2.8
+current_version_description: Clarify `=` and `==` inside test functions; make liascript link(s) point to first page; format bash code blocks
 module_type: standard
 docs_version: 1.2.1
 language: en
@@ -59,7 +59,7 @@ previous_sequential_module: bash_103_combining_commands
 
 @version_history 
 
-Previous versions: 
+Previous versions:
 
 - [1.1.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/4347cd14c9f5a3fd110910ec09c0560a46e390bd/bash_conditionals_loops/bash_conditionals_loops.md#1): Clarify instructions in the getting started section.
 - [1.0.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/82883e76e9b41dca4e6caea5734cd518805bd3fe/bash_conditionals_loops/bash_conditionals_loops.md#1): Initial version
@@ -224,7 +224,7 @@ The `learning_bash` folder contains a few different types of files and folders f
 
 Try copying this code into your command line interface and see what happens:
 
-```
+```bash
 for file in *.dat
 do
   echo $file is a data file
@@ -244,13 +244,13 @@ In the first line `for file in *.dat` we are telling Bash that the variable "fil
 **Variable names**
 ===================
 
-You can name your variable anything you want as long as there are no spaces in the name, but the best practice is to name it something informative that helps you understand what your code is doing. For example both of  these have the same output as the code block above:
+You can name your variable anything you want as long as there are no spaces in the name, but the best practice is to name it something informative that helps you understand what your code is doing. For example both of these have the same output as the code block above:
 
-```
+```bash
 for z in *.dat; do echo $z; done
 ```
 
-```
+```bash
 for swivel_chair in *.dat; do echo $swivel_chair; done
 ```
 The first one doesn't give any context for what the variable `$z` represents, and the second will be extra confusing to you and anyone else who wants to know what your code does later!
@@ -261,7 +261,7 @@ Any command or sequence of commands can be repeated using a for loop.
 
 Maybe you to see all of the data files and all of their contents, and also want that information displayed with an empty line between each animal's data:
 
-```
+```bash
 for file in *.dat
 do
   echo $file
@@ -272,7 +272,7 @@ done
 
 Maybe you want to create a new file called `my_data` that contains all of that output you just printed. The best way to do that is to redirect each line of output to be appended to `my_data`:
 
-```
+```bash
 for file in *.dat
 do
   echo $file >> my_data
@@ -285,7 +285,7 @@ There isn't any output because you redirected it all, so use `cat my_data` to ch
 
 You can also create loops that redirect some output but while also showing you output. This can be a way to check that your code is working if you have a loop that takes a long time to run.
 
-```
+```bash
 for file in *.txt
 do
   echo $file >> my_animals
@@ -303,7 +303,7 @@ You can even put a loop inside of another loop! This is called **nesting** and n
 
 Perhaps you want to make some empty files for giant squid, elephant, and albatross. You just want each of these animals to have an empty `.txt` file and and empty `.dat` file. A nested loop can be a good way to do this:
 
-```
+```bash
 for animal in giant_squid elephant albatross
 do
   for filetype in .txt .dat
@@ -340,7 +340,7 @@ For loops are powerful tools in many programming languages because they let you 
 
 In a previous example you created files including `giant_squid.txt`, `elephant.txt`, and `albatross.txt`. If you now want to make each of these files contain their name, what should go in the three blanks in this code?
 
-```
+```bash
 ___1___ giant_squid elephant albatross
 ___2___
   echo $animal >> $animal.txt
@@ -356,7 +356,7 @@ ___3___
 
 The word `in` after defining the variable is important, and the command `do` comes before `done`. The correct code is:
 
-```
+```bash
 for animal in giant_squid elephant albatross
 do
   echo $animal >> $animal.txt
@@ -429,7 +429,7 @@ The three lines together make up the conditional statement.
 
 Let's see a working example:
 
-```
+```bash
 if [ 5 -eq 05 ]
 then echo "integer equality"
 fi
@@ -454,7 +454,7 @@ The statement `[ 5 -eq 05 ]` is checking if the numbers `5` and `05` are equal t
 
 You can also give instructions for what to do if the statement evaluates as false by adding a line starting with `else` after your `then` statement:
 
-```
+```bash
 if [ 5 -eq 05 ]
 then echo "integer equality"
 else echo "these numbers are not equal"
@@ -491,7 +491,7 @@ Variables in Bash are assigned values using the equals symbol `=` with **no spac
 
 You can have as many `elif` and `then` pairs as you want, but as soon as one statement is true, the code will do that action **and then stop**. It will not continue to check the remaining statements! Try to think about what this code will output, then run it and check if you were right:
 
-```
+```bash
 c=100
 if [ $c -lt 10 ]
 then echo "$c is a single digit number"
@@ -518,7 +518,7 @@ Each of these examples is based on the directory `learning_bash-main` that you d
 
 The test statement `[ -s FILE ]` is true if `FILE` exists is non-empty and false if `FILE` doesn't exist or exists but is empty.
 
-```
+```bash
 for file in *.txt
 do
    if [ -s $file ]
@@ -539,7 +539,7 @@ Also take a look at lines 5 and 6: both run whenever the statement `[ -s $file ]
 
 The test statement `[ STRING1 = STRING2 ]` is true if the two strings are the same, and false if they differ at all. For example `[ 5 = 05 ]` is false because the string `5` and the string `05` are not the same string of characters.
 
-```
+```bash
 for file in *.txt
 do
   if [[ "$file" = *bear* ]]
@@ -572,7 +572,7 @@ Bash can also think of all sorts of other commands as statements. In general a c
 
 </div>
 
-```
+```bash
 for file in *.txt
 do
   if grep Ursus $file
@@ -633,7 +633,7 @@ It is more important to know what types of commands are possible so that you can
 
 Without running this code, predict what it will do:
 
-```
+```bash
 for number in 1 2 3 4 5 6 7
 do
   if [ $number -gt 4 ]

--- a/bash_scripts/bash_scripts.md
+++ b/bash_scripts/bash_scripts.md
@@ -2,8 +2,8 @@
 module_id: bash_scripts
 author:   Elizabeth Drellich
 email:    drelliche@chop.edu
-version: 1.3.5
-current_version_description: Added webinar links to additional resources; make liascript link(s) point to first page
+version: 1.4.0
+current_version_description: Distinguish bash input and output code blocks
 module_type: standard
 docs_version: 2.0.0
 language: en
@@ -59,9 +59,9 @@ previous_sequential_module: bash_conditionals_loops
 
 Previous versions: 
 
+- [1.3.5](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/d367a7d5a0e9b6abdf67883b31d4a8894a13b17a/bash_scripts/bash_scripts.md#1): Added webinar links to additional resources; make liascript link(s) point to first page
 - [1.2.2](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/768ecbb4a71dd338c90d78dab1ee5a6cc7b39581/bash_scripts/bash_scripts.md#1): Updated metadata and macros
 - [1.1.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/3cdfc807be26db43d837de9e325b66c9213a3d5c/bash_scripts/bash_scripts.md#1): Improved instructions for downloading learning_bash repository.
-- [1.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/): Initial version.
 @end
 
 
@@ -112,7 +112,7 @@ Even if you don't care about reproducibility or reusability, putting a long comm
 
 Even the simplest of loops are easier handle as scripts than typed into the command line. Compare entering something like `bash scripts/identify_dat_files.sh` to entering this correctly:
 
-```
+```bash
 for file in *.dat
 do
   echo $file is a data file
@@ -133,7 +133,7 @@ First line
 
 Sometimes scripts contain a special first line that looks something like this:
 
-```
+```bash
 #! /usr/bin/bash
 ```
 
@@ -199,7 +199,7 @@ In this section we will learn how to use the pre-written scripts in the `scripts
 
 Navigate to the `scripts` folder and use `ls` to take a look at the example scripts there.
 
-```
+```+output
 count_mammals.sh
 count_type.sh
 interactive_count_type.sh
@@ -222,7 +222,7 @@ The command `bash` takes a file as its argument and executes all of the commands
 
 The `count_mammals.sh` script contains two lines of code:
 
-```
+```bash
 count=$(grep mammal Animals.csv | wc -l)
 
 echo There are $count mammals on the list.
@@ -244,19 +244,19 @@ The first line of code above assumes that there is a file called `Animals.csv` i
 
 Give it a try:
 
-```
+```bash
 count=$(grep mammal Animals.csv | wc -l)
 ```
 
 If you are in `scripts` you will get the message:
 
-```
+```+output
 No such file or directory
 ```
 
 But if you are in `learning_bash-main` you won't get any output at all. This is because the code is defining a variable, `count`. Try running the second line and see what happens:
 
-```
+```bash
 echo There are $count mammals on the list.
 ```
 
@@ -268,7 +268,7 @@ Try it yourself
 ---
 Use `pwd` to check that you are currently in the `learning_bash-main` directory, and if not, navigate there. Now you can call the script with the `bash` command:
 
-```
+```bash
 bash scripts/count_mammals.sh
 ```
 
@@ -278,7 +278,7 @@ The `bash` command takes only one argument, the name of a file, but that file ma
 
 The `count_type.sh` script takes one argument. Give it a try:
 
-```
+```bash
 bash scripts/count_type.sh mammal
 ```
 
@@ -290,7 +290,7 @@ The third script also takes an argument, but instead of getting that argument fr
 
 Try running it:
 
-```
+```bash
 bash scripts/interactive_count_type.sh
 ```
 
@@ -334,13 +334,17 @@ In this section you will be writing some scripts of your own. For consistency, p
 
 Let's start by making a file
 
-```
+```bash
 echo "echo This is my first script" > first_script.sh
 ```
 
-You should now have a file called `first_script.sh` which contains the single line
+You should now have a file called `first_script.sh` which contains a single line
 
+```bash
+cat first_script.sh
 ```
+
+```+output
 echo This is my first script
 ```
 
@@ -361,7 +365,7 @@ If your script has an argument, you need to be able to refer to that argument in
 
 Let's update `first_script.sh` to an argument:
 
-```
+```bash
 echo "echo My script can take an argument, like \$1" >> first_script.sh
 ```
 
@@ -376,7 +380,7 @@ Without that backslash, `$1` will be interpreted as a **variable**, which you pr
 
 Use `cat` to check that `first_script.sh` now contains two lines:
 
-```
+```+output
 echo This is my first script
 echo My script can take an argument, like $1
 ```
@@ -392,19 +396,19 @@ Using a text editor to write directly to your file `first_script.sh` can sometim
 
 Now that `first_script.sh` takes an argument, try running it and see what happens:
 
-```
+```bash
 bash first_script.sh my_argument
 ```
 
 The order in which you enter arguments into the command line matters. Let's make a new script that will take 3 arguments:
 
-```
+```bash
 echo "echo \$3 \$2 \$1" > reverse_three.sh
 ```
 
 The `reverse_three.sh` script takes three arguments, let's give it a try:
 
-```
+```bash
 bash reverse_three.sh alpha beta gamma
 ```
 
@@ -419,7 +423,7 @@ If you give a script arguments it doesn't use, it just ignores the extra argumen
 
 An argument could even have spaces in it, as long as you surround the argument with quotes. Consider the following commands, how do you think their output will differ? Run them and see if you were right.
 
-```
+```bash
 bash first_script.sh "I love Bash"
 bash first_script.sh I love Bash
 bash reverse_three.sh "I love Bash"
@@ -431,7 +435,7 @@ bash reverse_three.sh I love Bash
 
 Let's take a closer look at the scripts we saw in the previous section of the module. The first line of `count_mammals.sh` reads
 
-```
+```bash
 count=$(grep mammal Animals.csv | wc -l)
 ```
 
@@ -459,7 +463,7 @@ Why use variables?
 ---
 Consider another script that contains only one line:
 
-```
+```bash
 echo There are $(grep mammal Animals.csv | wc -l) mammals on the list.
 ```
 
@@ -486,7 +490,7 @@ If you look at older Bash scripts, you may see backticks `\`commands here\`` use
 
 While backticks will work to create a subshell, the `$()` construction has some advantages, namely that you can nest subshells like this:
 
-```
+```bash
 $(outer subshell depends on $(inner subshell))
 ```
 
@@ -501,7 +505,7 @@ You saw this in action when you called the script `interactive_count_type.sh` ea
 
 Interactive scripts are most powerful when they include useful prompts. Let's take a look at one:
 
-```
+```bash
 echo Enter your new variable here:
 read new_var
 echo You entered "$new_var"
@@ -526,7 +530,7 @@ An interactive script will execute each line in the order it appears. You can pr
 
 You are now going to create an interactive script that uses several of the techniques we have just learned. Since the script will contain several lines, it will be helpful to use a text editor. We suggest `nano` which you can open from the command line with
 
-```
+```bash
 nano my_interactive_script.sh
 ```
 
@@ -547,7 +551,7 @@ Now it is time to put some commands into this script. When you think your script
 
 Here is an example you can copy and experiment with by changing some of the lines to other commands you know. 
 
-```
+```bash
 echo What is your name?
 read name
 echo What is your favorite number $name?
@@ -562,7 +566,7 @@ echo That is an interesting answer $name. My favorite number is $(($number * 2 +
 
 Bash can do mathematical operations, including `+`, `-`, `*`, `/`, but they must be inside of a special [Arithmetic Expansion](https://www.gnu.org/software/bash/manual/html_node/Arithmetic-Expansion.html) subshell, surrounded by double parentheses:
 
-```
+```bash
 $((mathematical expression here))
 ```
 
@@ -571,7 +575,7 @@ $((mathematical expression here))
 <div class = "help">
 <b style="color: rgb(var(--color-highlight));">Troubleshooting help</b><br>
 
-Each line of code must be on a single line inside the plain text file. For example if you insert a line break into the last line, the `echo` command will only know to print out the text on the same line as it, and Bash will try to treat the next line as a new command. This will result in an error message like "command not found"
+Each line of code must be on a single line inside the plain text file. For example if you insert a line break into the last line, the `echo` command will only know to print out the text on the same line as it, and Bash will try to treat the next line as a new command. This will result in an error message like "command not found."
 
 </div>
 
@@ -596,42 +600,37 @@ echo There are $count lines in Animals.csv that contain the string \"$string\".
 
 Without looking at the contents of the original file `interactive_count_type.sh`, what should go in the three blank spots in the code?
 
-1.
+1
+
 [[echo]]
 ***
-
 <div class = "answer">
 
 The  `echo` command tells Bash to print out the question "What string do you want to search for?"
 
 </div>
-
 ***
 
+2
 
-
-2.
 [[read]]
 ***
-
 <div class = "answer">
 
 The  `read` command tells Bash to expect user input and to save that input as a variable.
 
 </div>
-
 ***
 
-3.
+3
+
 [[string]]
 ***
-
 <div class = "answer">
 
 The variable `$string` is called in the last two lines of the script, so the user's input must be assigned to the variable `string`.
 
 </div>
-
 ***
 
 

--- a/bash_scripts/bash_scripts.md
+++ b/bash_scripts/bash_scripts.md
@@ -536,7 +536,7 @@ nano my_interactive_script.sh
 
 This will open the nano text editor inside of the shell where you will be able to edit the (currently empty) plain text file `my_interactive_script.sh`
 
-![The empty file my_interactive_script.sh opened in nano.](media/empty_nano_window.png)
+![The empty file my_interactive_script.sh opened in nano.](media/empty_nano_window.png)<!-- style = "border :1px solid rgb(var(--color-highlight));" -->
 
 <div class = "help">
 <b style="color: rgb(var(--color-highlight));">Troubleshooting help</b><br>


### PR DESCRIPTION
This addresses the 5 Bash modules and gets them up to date with the latest standards for input and output blocks of code. Please note:

- This in a minor change in 4 of the modules, but only a revision in `bash_conditionals_loops` because that module contains no output code blocks. Modules containing output code blocks will now look noticeably different to learners, even if the content has not changed.
- Additional scaffolding was added to `bash_command_line_101` to clarify how the code blocks are being used, and describe the command prompt in a more useful way to learners who have never encountered it before.
- In some places, an additional code block was added to show that a file is being accessed using `cat` so that the contents of that file can be shown as output.
- While this addresses some of the issues in https://github.com/arcus/education_modules/issues/860, it does **not** close that issue.

Please read through these modules for logic and flow, since this reformatting of code blocks is, for some modules, a somewhat significant change.