### PR TITLE
add link check workflow

### DIFF
--- a/.github/workflows/link_check_cron.yml
+++ b/.github/workflows/link_check_cron.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           title: Link Checker Report
           content-filepath: issue_content.md
-          labels: report, automated issue, bug
+          labels: bug

--- a/.github/workflows/link_check_cron.yml
+++ b/.github/workflows/link_check_cron.yml
@@ -1,0 +1,42 @@
+name: Link check cron job
+
+# the role of this link check workflow is to periodically look for links
+# that have died since last QA. If broken links are found, action still passes
+# and an issue is created
+
+on:
+  workflow_dispatch: #can also run on demand if desired
+  schedule:
+    - cron: "05 7 */14 * 2" #run at 7:05 am every 14 days on Tuesday 
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.9.0
+
+      - name: Remove files with known issues
+        run: |
+          awk '/^###/{printf $0; next} 1' ./lychee/out.md | awk 'BEGIN {RS="\n\n"; ORS="\n\n"} !/how_to_troubleshoot|macros\.md|macros_python\.md|demystifying_regular_expressions/' > issue_content.md
+         # remove all content for failed links in above files (which have necessary content that cause failures)
+
+      - name: Check for remaining issues
+        run: |
+          if grep -q "###" issue_content.md 
+            then 
+              echo "FILE_HAS_CONTENT=1" >> $GITHUB_ENV
+            else 
+              echo "FILE_HAS_CONTENT=0" >> $GITHUB_ENV
+          fi
+
+      - name: Create Issue From File
+        if: env.FILE_HAS_CONTENT != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: issue_content.md
+          labels: report, automated issue, bug


### PR DESCRIPTION
periodically check for any links that no longer work in our module content. 

------
A few notes: 

Because there are files that always cause some failures (e.g., the intentionally bad urls being used as an example in a regex module), any errors found in a few files (how_to_troubleshoo.md, |macros.md, macros_python.md, and demystifying_regular_expressions.md) are excluded from the report that gets generated. This means this workflow will not catch any actually bad links in those modules. For a later iteration, we can always refine the code to not exclude those files all together, and instead just remove mentions of the links that we expected to fail, but this feels like a good skateboard. 

Also, while the cron syntax is valid, I'm not 100% sure it will accomplish what I actually want for it to accomplish (which is running only once every two weeks on a Tuesday, so we run it just before either backlog refinement or sprint planning). I don't feel like waiting to find out in a different repo though, and the worst consequences of it not working as expected are either (a) we get annoyed by way too many issues being created or (b) I realize in a month that it wasn't running when I wanted it to. These both seem like they are fine to happen on production. 

LMK if you have any questions or want me to walk you through the code in more depth or think the file needs more verbose commenting