### PR TITLE
update directory structure requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_update_checklist_v5.md
+++ b/.github/ISSUE_TEMPLATE/docs_update_checklist_v5.md
@@ -1,0 +1,37 @@
+---
+name: Checklist for updating modules to v5
+about: Checklist for updating a module to comply with docs.md v5
+title: Docs v5 Update Checklist
+assignees: ''
+
+---
+
+# Module Update Checklist
+----
+Name of Module: {take from the title of the main markdown file for the module}
+PR for module update: #[PR number here]
+
+This is the checklist for bringing a module up to date with the latest major version of docs.md: v5
+
+*Note*: There is no checklist to update to v4 because all modules were updated with the v4 change, adding `module_id` to front matter, in the same PR that updated docs.md.
+To bring a module at v2 up to date with v5, for example, you only need to use the checklists for v3 and v5. 
+
+## Summary of changes
+
+New requirements for directory structure. 
+Many modules will already follow these conventions, but for those that don't change the subdirectory names and organization to match the new requirements.
+
+## Module directory structure 
+
+* [ ] The module content markdown file is the only file on the first level of the directory. All other files are contained within subdirectories.
+* [ ] Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
+* [ ] Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
+* [ ] Data files are saved within a `data` folder within the module directory. 
+* [ ] The only subdirectories that exist are `media`, `code`, and `data`.
+
+## Final check
+
+When you're ready to finalize the updated module, do the following in the module front matter:
+
+* [ ] Increment `version` for the module. This is a revision (although the module content isn't changing at all, the metadata is changing slightly as `docs_version` is updated). 
+* [ ] Update `docs_version` to 5.0.0

--- a/.github/ISSUE_TEMPLATE/qa-for-exercise-modules.md
+++ b/.github/ISSUE_TEMPLATE/qa-for-exercise-modules.md
@@ -11,7 +11,7 @@ assignees: ''
 ----
 Date: {yyyy-mm-dd}
 Reviewer: {your name}
-qa_template_version: 2.0.1
+qa_template_version: 3.0.0
 Name of Module: {take from the title of the main markdown in the PR}
 Current Liascript URL: {makes it easy for reviewers and authors to look at content as learners will}
 
@@ -20,7 +20,11 @@ Current Liascript URL: {makes it easy for reviewers and authors to look at conte
 ## Directory structure
 * [ ] Folder and file names use lowercase and underscores (no dashes)
 * [ ] Main module directory folder name is identical to the name of the module content markdown file.
+* [ ] The module content markdown file is the only file on the first level of the directory. All other files are contained within subdirectories.
 * [ ] Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
+* [ ] Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
+* [ ] Data files are saved within a `data` folder within the module directory. 
+* [ ] The only subdirectories that exist are `media`, `code`, and `data`.
 
 ## Module Organization
 * [ ] Front matter is at the very top of the file

--- a/.github/ISSUE_TEMPLATE/qa-for-standard-modules.md
+++ b/.github/ISSUE_TEMPLATE/qa-for-standard-modules.md
@@ -11,7 +11,7 @@ assignees: ''
 ----
 Date: {yyyy-mm-dd}
 Reviewer: {your name}
-qa_template_version: 2.0.1
+qa_template_version: 3.0.0
 Name of Module: {take from the title of the main markdown in the PR}
 Current Liascript URL: {makes it easy for reviewers and authors to look at content as learners will}
 
@@ -20,7 +20,11 @@ Current Liascript URL: {makes it easy for reviewers and authors to look at conte
 ## Directory structure
 * [ ] Folder and file names use lowercase and underscores (no dashes)
 * [ ] Main module directory folder name is identical to the name of the module content markdown file.
+* [ ] The module content markdown file is the only file on the first level of the directory. All other files are contained within subdirectories.
 * [ ] Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
+* [ ] Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
+* [ ] Data files are saved within a `data` folder within the module directory. 
+* [ ] The only subdirectories that exist are `media`, `code`, and `data`.
 
 ## Module Organization
 * [ ] Front matter is at the very top of the file

--- a/.github/ISSUE_TEMPLATE/qa-for-wrapper-modules.md
+++ b/.github/ISSUE_TEMPLATE/qa-for-wrapper-modules.md
@@ -11,7 +11,7 @@ assignees: ''
 ----
 Date: {yyyy-mm-dd}
 Reviewer: {your name}
-qa_template_version: 2.0.1
+qa_template_version: 3.0.0
 Name of Module: {take from the title of the main markdown in the PR}
 Current Liascript URL: {makes it easy for reviewers and authors to look at content as learners will}
 
@@ -20,7 +20,11 @@ Current Liascript URL: {makes it easy for reviewers and authors to look at conte
 ## Directory structure
 * [ ] Folder and file names use lowercase and underscores (no dashes)
 * [ ] Main module directory folder name is identical to the name of the module content markdown file.
+* [ ] The module content markdown file is the only file on the first level of the directory. All other files are contained within subdirectories.
 * [ ] Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
+* [ ] Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
+* [ ] Data files are saved within a `data` folder within the module directory. 
+* [ ] The only subdirectories that exist are `media`, `code`, and `data`.
 
 ## Module Organization
 * [ ] Front matter is at the very top of the file

--- a/docs.md
+++ b/docs.md
@@ -96,6 +96,7 @@ You can also see revisions and comments on [pull requests for other modules that
   * Main module directory folder name is identical to the name of the module content markdown file (this name is called the [module\_id](#module_id)).
   * Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
   * Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
+  * Data files are saved within a `data` folder within the module directory. 
 
 <div class = "important">
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>

--- a/docs.md
+++ b/docs.md
@@ -95,7 +95,7 @@ You can also see revisions and comments on [pull requests for other modules that
   * Folder and file names use lowercase and underscores (no dashes)
   * Main module directory folder name is identical to the name of the module content markdown file (this name is called the [module\_id](#module_id)).
   * Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
-  * Code files (including scripts, notebooks, etc.) are saved within a `src` folder within the module directory
+  * Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
 
 <div class = "important">
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>

--- a/docs.md
+++ b/docs.md
@@ -2,8 +2,8 @@
 
 author:   DART Team
 email:    dart@chop.edu
-version:  4.0.3
-current_version_description: Added module\_id as required frontmatter field for all modules; make liascript link(s) point to first page; move standard learning_objectives language to macro;
+version:  5.0.0
+current_version_description: Update module directory requirements
 language: en
 narrator: UK English Female
 title: DART LiaScript docs
@@ -25,10 +25,9 @@ try {
 @version_history
 Previous versions: 
 
+- [4.0.3](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/d367a7d5a0e9b6abdf67883b31d4a8894a13b17a/docs.md): Added module\_id as required frontmatter field for all modules; make liascript link(s) point to first page; move standard learning_objectives language to macro;
 - [3.1.2](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/d4409612159096b9f3bebfc2f7ddf795b92496cd/docs.md#1): Updated definition of learn\_to\_code collection
 - [3.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/cd0da90a30910c22d5502f509125892a761c3145/docs.md#1): Added collection as a front matter field, added text as a data\_domain, fixed typos
-- [2.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/89cadafc6f1f9c83e4de93e7d55cd9427866f9f2/docs.md#1): Made coding\_required a mandatory front matter field for all modules
-- [1.3.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/b453a05b5ac756fb5c7b183deae9d4fc91b3a617/docs.md#1): Clarified that version\_history cannot be blank but sets\_you\_up\_for and depends\_on\_knowledge\_available\_in can
 @end
 
 import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_templates/macros.md

--- a/docs.md
+++ b/docs.md
@@ -25,7 +25,7 @@ try {
 @version_history
 Previous versions: 
 
-- [3.1.2](): Updated definition of learn\_to\_code collection
+- [3.1.2](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/d4409612159096b9f3bebfc2f7ddf795b92496cd/docs.md#1): Updated definition of learn\_to\_code collection
 - [3.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/cd0da90a30910c22d5502f509125892a761c3145/docs.md#1): Added collection as a front matter field, added text as a data\_domain, fixed typos
 - [2.0.0](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/89cadafc6f1f9c83e4de93e7d55cd9427866f9f2/docs.md#1): Made coding\_required a mandatory front matter field for all modules
 - [1.3.1](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/b453a05b5ac756fb5c7b183deae9d4fc91b3a617/docs.md#1): Clarified that version\_history cannot be blank but sets\_you\_up\_for and depends\_on\_knowledge\_available\_in can

--- a/docs.md
+++ b/docs.md
@@ -94,9 +94,10 @@ You can also see revisions and comments on [pull requests for other modules that
 
   * Folder and file names use lowercase and underscores (no dashes)
   * Main module directory folder name is identical to the name of the module content markdown file (this name is called the [module\_id](#module_id)).
-  * Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
-  * Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
-  * Data files are saved within a `data` folder within the module directory. 
+  * The module markdown file should be the only file on the first level of the module directory. All other files should be contained in one of the following folders. If you come across a need to include a file that does not neatly fit into one of these categories, [submit an issue](https://github.com/arcus/education_modules/issues/new) so we can create a new category if necessary:
+    *  Images, videos, and other audio-visual assets are saved within a `media` folder within the module directory
+    * Code files (including scripts, notebooks, etc.) are saved within a `code` folder within the module directory
+    * Data files are saved within a `data` folder within the module directory. 
 
 <div class = "important">
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>


### PR DESCRIPTION
data folder technically new to docs, but already in use. 

Also, changed `src` to `code` because `src` is not being used by anyone yet (mostly `notebooks` is in use, but that isn't well named for non-notebook files), so it will require the same amount of edits to bring up to standards either way, and `code` is more self-explanatory for learners who might poke around in our repo on their own to try to find materials. 


Made edits to the QA templates for now, though won't be long until we can deploy the action that looks for this, at which point we should be able to just remove that section from the manual QA process all together. 