### PR TITLE
hide quiz explanations when questions not answered yet

### DIFF
--- a/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
+++ b/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
@@ -2,7 +2,7 @@
 module_id: python_basics_lists_dictionaries
 author:   Meredith Lee
 email:    leemc@chop.edu
-version: 1.2.2
+version: 1.2.3
 current_version_description: Replaced SageMathCells with Pyodide cells for better usability.
 module_type: standard
 docs_version: 3.0.0

--- a/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
+++ b/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md
@@ -230,33 +230,34 @@ The code cells above are linked, meaning that all of the cells "remember" the co
 
 1. Which of the following is FALSE about lists? Select all that apply.
 
-    [( )] Lists are changeable; items can be added, removed, or replaced after the list is created.
-    [( )] Lists can be assigned to variables.
-    [( )] Lists can contain a mix of data types.
-    [(X)] Lists are unordered; you cannot access an item in the list by its position.
-    ***
-    <div class = "answer">
 
-    Lists are changeable, can be stored in variables for later use (even though we didn't explicitly discuss it, the list on the previous page was assigned to the variable `produce`), can contain a mix of data types, and they are **ordered**, meaning that items remain in the position that they were put into the list. You can access or edit list items by value **or** position (also called the **index**).
+[( )] Lists are changeable; items can be added, removed, or replaced after the list is created.
+[( )] Lists can be assigned to variables.
+[( )] Lists can contain a mix of data types.
+[(X)] Lists are unordered; you cannot access an item in the list by its position.
+***
+<div class = "answer">
 
-    </div>
-    ***
+Lists are changeable, can be stored in variables for later use (even though we didn't explicitly discuss it, the list on the previous page was assigned to the variable `produce`), can contain a mix of data types, and they are **ordered**, meaning that items remain in the position that they were put into the list. You can access or edit list items by value **or** position (also called the **index**).
+
+</div>
+***
 
 2. Given the following list of numbers, what is the **index** of the number **15**?
 
     `[2, 14, 9, 101, 15, 37]`
 
-    [( )] 5
-    [(X)] 4
-    [( )] 15
-    [( )] 6
-    ***
-    <div class = "answer">
+[( )] 5
+[(X)] 4
+[( )] 15
+[( )] 6
+***
+<div class = "answer">
 
-    Indexing in Python begins with **0**, not 1, and so the index of 15, which is the fifth item in the list, is **4**.  
+Indexing in Python begins with **0**, not 1, and so the index of 15, which is the fifth item in the list, is **4**.  
 
-    </div>
-    ***
+</div>
+***
 
 ## Dictionaries
 
@@ -386,49 +387,49 @@ We've just gone through quite a few useful list and dictionary methods, and you 
 
 1. True or False: Duplicate key-value pairs are allowed in dictionaries.
 
-    [( )] True
-    [(X)] False
-    ***
-    <div class = "answer">
+[( )] True
+[(X)] False
+***
+<div class = "answer">
 
-    While **values** can be repeated in a dictionary, each **key** must be unique. However, you can have multiple values for a key by putting those values in a list.
+While **values** can be repeated in a dictionary, each **key** must be unique. However, you can have multiple values for a key by putting those values in a list.
 
-    </div>
-    ***
+</div>
+***
 
 2. How would you access all of the countries (the "keys") in the dictionary below? 
 
      `capital_cities = {"Afghanistan" : "Kabul", "Albania" : "Tirana", "Algeria" : "Algiers", "Andorra" : "Andorra la Vella"}`
 
-    [[capital_cities.keys()]]
-    <script>
-  let input = "@'input".trim();
-  input == "capital_cities.keys()";
+[[capital_cities.keys()]]
+<script>
+let input = "@'input".trim();
+input == "capital_cities.keys()";
 </script>
-    ***
-    <div class = "answer">
+***
+<div class = "answer">
 
-    To return the keys of a dictionary, you use the `.keys()` dictionary method on the `capital_cities` dictionary. So the correct answer is `capital_cities.keys()`.
+To return the keys of a dictionary, you use the `.keys()` dictionary method on the `capital_cities` dictionary. So the correct answer is `capital_cities.keys()`.
 
-    </div>
-    ***
+</div>
+***
 
 3. How would you add the the country of Angola and its capital city of Luanda to the dictionary below?
 
     `capital_cities = {"Afghanistan" : "Kabul", "Albania" : "Tirana", "Algeria" : "Algiers", "Andorra" : "Andorra la Vella"}`
 
-    [[capital_cities["Angola"] = "Luanda"]]
-    <script>
-    let input = "@'input".replace(/\s/g, "");
-    input == 'capital_cities["Angola"]="Luanda"' || input == "capital_cities['Angola']='Luanda'";
-    </script>
-    ***
-    <div class = "answer">
+[[capital_cities["Angola"] = "Luanda"]]
+<script>
+let input = "@'input".replace(/\s/g, "");
+input == 'capital_cities["Angola"]="Luanda"' || input == "capital_cities['Angola']='Luanda'";
+</script>
+***
+<div class = "answer">
 
-    To add a new key-value pair to a dictionary, we use subsetting notation.
+To add a new key-value pair to a dictionary, we use subsetting notation.
 
-    </div>
-    ***
+</div>
+***
 
 
 ## Additional Resources

--- a/python_basics_loops_conditionals/python_basics_loops_conditionals.md
+++ b/python_basics_loops_conditionals/python_basics_loops_conditionals.md
@@ -2,7 +2,7 @@
 module_id: python_basics_loops_conditionals
 author:   Meredith Lee
 email:    leemc@chop.edu
-version: 1.2.2
+version: 1.2.3
 current_version_description: Replaced SageMathCells with Pyodide cells for better usability
 module_type: standard
 docs_version: 1.2.0

--- a/python_basics_loops_conditionals/python_basics_loops_conditionals.md
+++ b/python_basics_loops_conditionals/python_basics_loops_conditionals.md
@@ -296,32 +296,30 @@ print(candy2)
 
 1. If we wanted to add another conditional statement at line 6 of the code cell above that would give 1 piece of candy to children who start with between 10 to 15 pieces (inclusive), what keyword would we use to start that line?
 
-    [( )] `for`
-    [( )] `if`
-    [(X)] `elif`
-    [( )] `else`
-    ***
-    <div class = "answer">
+[( )] `for`
+[( )] `if`
+[(X)] `elif`
+[( )] `else`
+***
+<div class = "answer">
 
-    Because we're checking for multiple conditions, we use the `elif` keyword. We use `if` for the first condition that we are testing; `else` is used at the end to catch anything that hasn't been explicitly handled by our preceding conditions. And we know that `for` is the keyword to begin a loop!
+Because we're checking for multiple conditions, we use the `elif` keyword. We use `if` for the first condition that we are testing; `else` is used at the end to catch anything that hasn't been explicitly handled by our preceding conditions. And we know that `for` is the keyword to begin a loop!
 
-    </div>
-    ***
+</div>
+***
+ How could you write the comparison at line 6 so that each child gets the correct number of pieces of candy? Select all that apply.
 
+[[X]] `10 <= i <= 15`
+[[ ]] `10 < i < 15`
+[[ ]] `i >= 10`
+[[X]] `10 <= i < 16`
+***
+<div class = "answer">
 
-2. How could you write the comparison at line 6 so that each child gets the correct number of pieces of candy? Select all that apply.
+Because we want to give an additional piece of candy to any student who started with between 10 and 15 pieces, we want to test if `i` is greater than or equal to 10, but less than or equal to 15 (which could also be expressed as less than 16, since we're working with integers). So the first and last choices are correct.
 
-    [[X]] `10 <= i <= 15`
-    [[ ]] `10 < i < 15`
-    [[ ]] `i >= 10`
-    [[X]] `10 <= i < 16`
-    ***
-    <div class = "answer">
-
-    Because we want to give an additional piece of candy to any student who started with between 10 and 15 pieces, we want to test if `i` is greater than or equal to 10, but less than or equal to 15 (which could also be expressed as less than 16, since we're working with integers). So the first and last choices are correct.
-
-    </div>
-    ***
+</div>
+***
 
 ## Additional Resources
 

--- a/python_basics_variables_functions_methods/python_basics_variables_functions_methods.md
+++ b/python_basics_variables_functions_methods/python_basics_variables_functions_methods.md
@@ -2,7 +2,7 @@
 module_id: python_basics_variables_functions_methods
 author:   Meredith Lee
 email:    leemc@chop.edu
-version: 1.1.3
+version: 1.1.4
 current_version_description: Implemented code blocks in pyodide; make liascript link(s) point to first page
 module_type: standard
 docs_version: 1.2.0

--- a/python_basics_variables_functions_methods/python_basics_variables_functions_methods.md
+++ b/python_basics_variables_functions_methods/python_basics_variables_functions_methods.md
@@ -173,10 +173,10 @@ Notice that in the above example, we have passed the `type("Hello World!")` func
 
 1. Which of the following are valid examples of Python code? Select all that apply.
 
-    [[X]] `len("Python is awesome!")`
-    [[X]] `"python".upper()`
-    [[X]] `type("4.3")`
-    [[X]] `type(True)`
+[[X]] `len("Python is awesome!")`
+[[X]] `"python".upper()`
+[[X]] `type("4.3")`
+[[X]] `type(True)`
 ***
 <div class = "answer">
 
@@ -199,10 +199,10 @@ print(x)
 
 2. To check that the string "Python is awesome!" ends in an exclamation point, we can use the code ` "Python is awesome!".endswith("!")`. In this case, the boolean value `True` will be returned, since "Python is awesome!" does indeed end in an exclamation point. What is `.endswith()` an example of?
 
-    [(X)] A method
-    [( )] A function
-    [( )] A string
-    [( )] A float
+[(X)] A method
+[( )] A function
+[( )] A string
+[( )] A float
 ***
 <div class = "answer">
 


### PR DESCRIPTION
Hi friends! @leemc-data-ed @rosemm Thanks to the power of open source, I was able to share some of our materials with learners at my new job who needed some additional resources on Python. And, thanks to the power of open source, I can directly fix an issue I noticed while looking over them again! Yay open source!!!!! 🎉

something must've changed in LiaScript, and now quiz explanations seem to not be playing nicely with indentations.

Removed indentations so that question explanations are only shown after correct answer or learner clicking to show solution. The indentation did make it look marginally nicer with the numbered questions, but this seems like the simplest solution, and its not ugly by any means. 

I did a quick grep on the repo to look for the pattern, and these 3 are the only affected modules I could locate! 